### PR TITLE
Metrics tiles

### DIFF
--- a/src/components/MetricsViewer.vue
+++ b/src/components/MetricsViewer.vue
@@ -10,7 +10,7 @@
       <div class="tile">
         <h3>Acceptance Rate Average</h3>
         <p>{{ acceptanceRateAverage.toFixed(2) }}%</p>
-        <p>On the last 28 days</p>
+        <p>Over the last 28 days</p>
       </div>
 
       <div class="tile">


### PR DESCRIPTION
This pull request introduces a new feature to the `MetricsViewer` component in the `src/components/MetricsViewer.vue` file. The changes include the addition of a new tiles section to display various metrics, and modifications to the data processing logic to calculate cumulative metrics and acceptance rate average. 

Here are the most important changes:

UI Enhancements:
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10R8-R35): Added a new tile-based layout for displaying metrics. Each tile represents a different metric.
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10R340-R355): Added CSS styles for the new tiles.

Data Calculation and Display:
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10R112-R117): Added new reactive variables to hold the values for the new metrics.
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10R173-R211): Modified the data processing logic to calculate cumulative values for the number of suggestions, acceptances, and lines of code accepted.
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10L171-R245): Changed the data processing logic to calculate the average acceptance rate.
* [`src/components/MetricsViewer.vue`](diffhunk://#diff-3232f8c11e48e57eba48531f39e477604432e91bafd81119783d472a38ad3f10L263-R324): Updated the return statement to include the new reactive variables.