### PR TITLE
Adds Copilot Chat Metrics support

### DIFF
--- a/src/components/CopilotChatViewer.vue
+++ b/src/components/CopilotChatViewer.vue
@@ -1,23 +1,192 @@
 <template>
-<div>
-   </div> 
+    <!-- API Error Message -->
+    <div v-if="apiError" class="error-message" v-html="apiError"></div>
+    <div v-if="!apiError">
+        <div class="tiles-container">      
+            <v-card elevation="4" color="white" variant="elevated" class="mx-auto my-3" style="width: 300px; height: 175px;">
+            <v-card-item>
+                <div>
+                <div class="text-overline mb-1" style="visibility: hidden;">filler</div>
+                <div class="text-h6 mb-1">Cumulative Number of Turns</div>
+                <div class="text-caption">
+                    Over the last 28 days
+                </div>
+                <p>{{ cumulativeNumberTurns }}</p>
+                </div>
+            </v-card-item>
+            </v-card>
+
+            <v-card elevation="4" color="white" variant="elevated" class="mx-auto my-3" style="width: 300px; height: 175px;">
+            <v-card-item>
+                <div>
+                <div class="text-overline mb-1" style="visibility: hidden;">filler</div>
+                <div class="text-h6 mb-1">Cumulative Number of Lines of Code Accepted</div>
+                <div class="text-caption">
+                    Over the last 28 days
+                </div>
+                <p>{{ cumulativeNumberAcceptances }}</p>
+                </div>
+            </v-card-item>
+            </v-card>
+        </div>
+        <v-main class="p-1" style="min-height: 300px;">
+
+        <v-container style="min-height: 300px;" class="px-4 elevation-2">
+
+        <h2>Total Suggestions Count | Total Acceptances Count</h2>
+        <Line :data="totalNumberAcceptancesAndTurnsChartData" :options="chartOptions" />
+
+        <h2>Total Active Copilot Chat Users</h2>
+        <Bar :data="totalActiveCopilotChatUsersChartData" :options="totalActiveChatUsersChartOptions" />
+
+        </v-container>
+      </v-main>
+    
+  </div>
+
 </template>
   
 <script lang="ts">
   import { defineComponent, ref } from 'vue';
   import { getGitHubCopilotMetricsApi } from '../api/GitHubApi';
   import { Metrics } from '../model/MetricsData';
+  import {
+  Chart as ChartJS,
+  ArcElement,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js'
+
+import { Line } from 'vue-chartjs'
+import { Bar } from 'vue-chartjs'
+
+ChartJS.register(
+  ArcElement, 
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend
+)
+
+
   
   
   export default defineComponent({
     name: 'CopilotChatViewer',
+    components: {
+    Bar,
+    Line
+    },
     setup() {
         const metrics = ref<Metrics[]>([]);
 
         const apiError = ref<string>('');
 
+        let cumulativeNumberAcceptances = ref(0);
+
+        let cumulativeNumberTurns = ref(0);
+
+        //Total Copilot Chat Active Users
+        const totalActiveCopilotChatUsersChartData = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });  
+
+        const totalActiveChatUsersChartOptions = {
+        responsive: true,
+        maintainAspectRatio: true,
+        scales: {
+            y: {
+            beginAtZero: true,
+            ticks: {
+                stepSize: 1
+            }
+            }
+        },
+        layout: {
+            padding: {
+            left: 50,
+            right: 50,
+            top: 50,
+            bottom: 50
+            }
+        },
+        };
+
+        const chartOptions = {
+            responsive: true,
+            maintainAspectRatio: true,
+            height: 300,
+            width: 300,
+            layout: {
+                padding: {
+                left: 150,
+                right: 150,
+                top: 20,
+                bottom: 40
+                }
+            },
+        };
+
+        //Total Number Acceptances And Turns
+        const totalNumberAcceptancesAndTurnsChartData = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });
+
         getGitHubCopilotMetricsApi().then(data => {
-        metrics.value = data;
+            metrics.value = data;
+
+            console.log('Metrics Data: ' + JSON.stringify(data));
+
+            cumulativeNumberTurns.value = 0;
+            const cumulativeNumberTurnsData = data.map(m => {        
+                cumulativeNumberTurns.value += m.total_chat_turns;
+                return m.total_chat_turns;
+            });
+
+            cumulativeNumberAcceptances.value = 0;
+            const cumulativeNumberAcceptancesData = data.map(m => {        
+                cumulativeNumberAcceptances.value += m.total_chat_acceptances;
+                return m.total_chat_acceptances;
+            });
+
+            totalNumberAcceptancesAndTurnsChartData.value = {
+            labels: data.map(m => m.day),
+                datasets: [
+                {
+                    label: 'Total Acceptances',
+                    data: cumulativeNumberAcceptancesData,
+                    backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                    borderColor: 'rgba(75, 192, 192, 1)'
+
+                },
+                {
+                    label: 'Total Turns',
+                    data: cumulativeNumberTurnsData,
+                    backgroundColor: 'rgba(153, 102, 255, 0.2)',
+                    borderColor: 'rgba(153, 102, 255, 1)'
+                }
+
+                ]
+            };
+
+            totalActiveCopilotChatUsersChartData.value = {
+            labels: data.map(m => m.day),
+            datasets: [
+            {
+                label: 'Total Active Copilot Chat Users',
+                data: data.map(m => m.total_active_chat_users),
+                backgroundColor: 'rgba(0, 0, 139, 0.2)', // dark blue with 20% opacity
+                borderColor: 'rgba(255, 99, 132, 1)'
+            }
+            ]
+            };
+
         }).catch(error => {
         console.log(error);
         // Check the status code of the error response
@@ -42,11 +211,15 @@
             
         });
 
-        return {  apiError, metrics };
+        return {  apiError, metrics, totalActiveCopilotChatUsersChartData, totalActiveChatUsersChartOptions,cumulativeNumberAcceptances, cumulativeNumberTurns, totalNumberAcceptancesAndTurnsChartData, chartOptions};
     }
   });
   </script>
   
   <style scoped>
-  
+  .tiles-container {
+  display: flex;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
   </style>

--- a/src/components/MetricsViewer.vue
+++ b/src/components/MetricsViewer.vue
@@ -375,14 +375,4 @@ export default defineComponent({
   justify-content: flex-start;
   flex-wrap: wrap;
 }
-
-.tile {
-  border: 1px solid #ccc;
-  box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.1), 
-              -3px -3px 5px rgba(255, 255, 255, 0.7);
-  padding: 20px;
-  border-radius: 10px;
-  width: 20%; 
-  margin: 1%;
-}
 </style>

--- a/src/model/MetricsData.ts
+++ b/src/model/MetricsData.ts
@@ -6,6 +6,9 @@ class Breakdown {
     lines_suggested: number;
     lines_accepted: number;
     active_users: number;
+    chat_acceptances: number;
+    chat_turns: number;
+    active_chat_users: number;
   
     constructor(data: any) {
       this.language = data.language;
@@ -15,6 +18,9 @@ class Breakdown {
       this.lines_suggested = data.lines_suggested;
       this.lines_accepted = data.lines_accepted;
       this.active_users = data.active_users;
+      this.chat_acceptances = data.chat_acceptances;
+      this.chat_turns = data.chat_turns;
+      this.active_chat_users = data.active_chat_users;
     }
   }
   
@@ -24,6 +30,9 @@ class Breakdown {
     total_lines_suggested: number;
     total_lines_accepted: number;
     total_active_users: number;
+    total_chat_acceptances: number;
+    total_chat_turns: number;
+    total_active_chat_users: number;
     day: string;
     breakdown: Breakdown[];
   
@@ -33,6 +42,9 @@ class Breakdown {
       this.total_lines_suggested = data.total_lines_suggested;
       this.total_lines_accepted = data.total_lines_accepted;
       this.total_active_users = data.total_active_users;
+      this.total_chat_acceptances = data.total_chat_acceptances;
+      this.total_chat_turns = data.total_chat_turns;
+      this.total_active_chat_users = data.total_active_chat_users;
       this.day = data.day;
       this.breakdown = data.breakdown.map((item: any) => new Breakdown(item));
     }


### PR DESCRIPTION
This pull request primarily includes changes to enhance the `CopilotChatViewer.vue` component and the `MetricsData.ts` model in the `src` directory. The most important changes are the addition of new elements and data visualizations to the `CopilotChatViewer.vue` component, and the extension of the `MetricsData.ts` model to support new metrics related to chat interactions.

User Interface Enhancements:

* [`src/components/CopilotChatViewer.vue`](diffhunk://#diff-7507fa0fc82a3addc43396ea8f10b51bc91d7fcc588f1f0c665be36ec06cd787R2-R189): Added an API error message to improve user experience when an error occurs.
* [`src/components/CopilotChatViewer.vue`](diffhunk://#diff-7507fa0fc82a3addc43396ea8f10b51bc91d7fcc588f1f0c665be36ec06cd787R2-R189): Introduced two new cards to display the cumulative number of chat turns and lines of code accepted over the last 28 days.
* [`src/components/CopilotChatViewer.vue`](diffhunk://#diff-7507fa0fc82a3addc43396ea8f10b51bc91d7fcc588f1f0c665be36ec06cd787R2-R189): Added charts to visualize the total number of chat acceptances and turns, as well as the total number of active Copilot chat users.
* [`src/components/CopilotChatViewer.vue`](diffhunk://#diff-7507fa0fc82a3addc43396ea8f10b51bc91d7fcc588f1f0c665be36ec06cd787L45-R224): Updated the return statement in the `defineComponent` function to include new data for the charts and cumulative metrics.
* [`src/components/CopilotChatViewer.vue`](diffhunk://#diff-7507fa0fc82a3addc43396ea8f10b51bc91d7fcc588f1f0c665be36ec06cd787L45-R224): Added new CSS styles for the tiles container.

Data Model Expansion:

* [`src/model/MetricsData.ts`](diffhunk://#diff-553ce53a43fcd06325608a89f3a82c38a2d1ec59b8bf9cc79927589d20b1f5a7R9-R11): Expanded the `Breakdown` and `Metrics` classes in the data model to include new fields for chat acceptances, chat turns, and active chat users. [[1]](diffhunk://#diff-553ce53a43fcd06325608a89f3a82c38a2d1ec59b8bf9cc79927589d20b1f5a7R9-R11) [[2]](diffhunk://#diff-553ce53a43fcd06325608a89f3a82c38a2d1ec59b8bf9cc79927589d20b1f5a7R21-R23) [[3]](diffhunk://#diff-553ce53a43fcd06325608a89f3a82c38a2d1ec59b8bf9cc79927589d20b1f5a7R33-R35) [[4]](diffhunk://#diff-553ce53a43fcd06325608a89f3a82c38a2d1ec59b8bf9cc79927589d20b1f5a7R45-R47)…