### PR TITLE
Add Pie chart of top 5 languages by acceptance rate

### DIFF
--- a/src/assets/copilot_metrics_response_sample.json
+++ b/src/assets/copilot_metrics_response_sample.json
@@ -1,10988 +1,11060 @@
 [
-  {
-    "day": "2024-03-18",
-    "total_suggestions_count": 8312,
-    "total_acceptances_count": 2009,
-    "total_lines_suggested": 35290,
-    "total_lines_accepted": 5038,
-    "total_active_users": 97,
-    "breakdown": [
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 2,
-        "lines_suggested": 133,
-        "lines_accepted": 66,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 68,
-        "acceptances_count": 3,
-        "lines_suggested": 90,
-        "lines_accepted": 3,
-        "active_users": 4
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 191,
-        "acceptances_count": 51,
-        "lines_suggested": 355,
-        "lines_accepted": 148,
-        "active_users": 4
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 1,
-        "lines_suggested": 81,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 2,
-        "lines_suggested": 27,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 2,
-        "lines_suggested": 24,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 11,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 34,
-        "acceptances_count": 2,
-        "lines_suggested": 100,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 542,
-        "acceptances_count": 154,
-        "lines_suggested": 1064,
-        "lines_accepted": 419,
-        "active_users": 13
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 162,
-        "acceptances_count": 46,
-        "lines_suggested": 223,
-        "lines_accepted": 61,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 701,
-        "acceptances_count": 213,
-        "lines_suggested": 1813,
-        "lines_accepted": 723,
-        "active_users": 29
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 257,
-        "acceptances_count": 92,
-        "lines_suggested": 316,
-        "lines_accepted": 102,
-        "active_users": 11
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 170,
-        "acceptances_count": 60,
-        "lines_suggested": 377,
-        "lines_accepted": 136,
-        "active_users": 8
-      },
-      {
-        "language": "c",
-        "editor": "vscode",
-        "suggestions_count": 110,
-        "acceptances_count": 20,
-        "lines_suggested": 339,
-        "lines_accepted": 67,
-        "active_users": 3
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 108,
-        "acceptances_count": 55,
-        "lines_suggested": 591,
-        "lines_accepted": 203,
-        "active_users": 8
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 7,
-        "lines_suggested": 16,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 79,
-        "acceptances_count": 26,
-        "lines_suggested": 100,
-        "lines_accepted": 26,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 250,
-        "acceptances_count": 58,
-        "lines_suggested": 561,
-        "lines_accepted": 84,
-        "active_users": 4
-      },
-      {
-        "language": "coffeescript",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 3,
-        "lines_suggested": 3,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 53,
-        "acceptances_count": 19,
-        "lines_suggested": 258,
-        "lines_accepted": 177,
-        "active_users": 6
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 190,
-        "acceptances_count": 109,
-        "lines_suggested": 804,
-        "lines_accepted": 522,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 54,
-        "acceptances_count": 22,
-        "lines_suggested": 103,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 961,
-        "acceptances_count": 209,
-        "lines_suggested": 1663,
-        "lines_accepted": 323,
-        "active_users": 10
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 170,
-        "acceptances_count": 29,
-        "lines_suggested": 391,
-        "lines_accepted": 80,
-        "active_users": 4
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1476,
-        "acceptances_count": 215,
-        "lines_suggested": 1987,
-        "lines_accepted": 280,
-        "active_users": 11
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 12,
-        "lines_suggested": 38,
-        "lines_accepted": 28,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 33,
-        "acceptances_count": 5,
-        "lines_suggested": 45,
-        "lines_accepted": 5,
-        "active_users": 3
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 8,
-        "lines_suggested": 60,
-        "lines_accepted": 53,
-        "active_users": 4
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 53,
-        "acceptances_count": 5,
-        "lines_suggested": 106,
-        "lines_accepted": 8,
-        "active_users": 5
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 72,
-        "acceptances_count": 16,
-        "lines_suggested": 286,
-        "lines_accepted": 199,
-        "active_users": 7
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 52,
-        "acceptances_count": 19,
-        "lines_suggested": 9746,
-        "lines_accepted": 20,
-        "active_users": 4
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 440,
-        "acceptances_count": 95,
-        "lines_suggested": 670,
-        "lines_accepted": 161,
-        "active_users": 8
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 2,
-        "lines_suggested": 6,
-        "lines_accepted": 3,
-        "active_users": 3
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 2,
-        "lines_suggested": 39,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 211,
-        "acceptances_count": 28,
-        "lines_suggested": 582,
-        "lines_accepted": 28,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 14,
-        "acceptances_count": 4,
-        "lines_suggested": 27,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "properties",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 16,
-        "acceptances_count": 5,
-        "lines_suggested": 44,
-        "lines_accepted": 15,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 85,
-        "acceptances_count": 32,
-        "lines_suggested": 287,
-        "lines_accepted": 89,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 25,
-        "acceptances_count": 10,
-        "lines_suggested": 79,
-        "lines_accepted": 45,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1535,
-        "acceptances_count": 360,
-        "lines_suggested": 11734,
-        "lines_accepted": 891,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 49,
-        "lines_accepted": 2,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-19",
-    "total_suggestions_count": 10148,
-    "total_acceptances_count": 2443,
-    "total_lines_suggested": 24150,
-    "total_lines_accepted": 5268,
-    "total_active_users": 121,
-    "breakdown": [
-      {
-        "language": "bat",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 11,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 34,
-        "acceptances_count": 0,
-        "lines_suggested": 36,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 123,
-        "acceptances_count": 62,
-        "lines_suggested": 180,
-        "lines_accepted": 76,
-        "active_users": 9
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java-properties",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json5",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 17,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 1,
-        "lines_suggested": 46,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 38,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 2,
-        "lines_suggested": 22,
-        "lines_accepted": 3,
-        "active_users": 3
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 115,
-        "acceptances_count": 14,
-        "lines_suggested": 254,
-        "lines_accepted": 19,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1162,
-        "acceptances_count": 346,
-        "lines_suggested": 2044,
-        "lines_accepted": 680,
-        "active_users": 17
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 263,
-        "acceptances_count": 94,
-        "lines_suggested": 373,
-        "lines_accepted": 134,
-        "active_users": 12
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 915,
-        "acceptances_count": 288,
-        "lines_suggested": 2670,
-        "lines_accepted": 955,
-        "active_users": 27
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 316,
-        "acceptances_count": 90,
-        "lines_suggested": 381,
-        "lines_accepted": 101,
-        "active_users": 7
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 124,
-        "acceptances_count": 65,
-        "lines_suggested": 440,
-        "lines_accepted": 190,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 464,
-        "acceptances_count": 125,
-        "lines_suggested": 1184,
-        "lines_accepted": 301,
-        "active_users": 13
-      },
-      {
-        "language": "c",
-        "editor": "vscode",
-        "suggestions_count": 36,
-        "acceptances_count": 9,
-        "lines_suggested": 57,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 155,
-        "acceptances_count": 79,
-        "lines_suggested": 795,
-        "lines_accepted": 532,
-        "active_users": 12
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 557,
-        "acceptances_count": 156,
-        "lines_suggested": 950,
-        "lines_accepted": 253,
-        "active_users": 7
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 80,
-        "acceptances_count": 19,
-        "lines_suggested": 280,
-        "lines_accepted": 48,
-        "active_users": 4
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 28,
-        "acceptances_count": 12,
-        "lines_suggested": 95,
-        "lines_accepted": 44,
-        "active_users": 4
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 13,
-        "lines_suggested": 89,
-        "lines_accepted": 20,
-        "active_users": 4
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1074,
-        "acceptances_count": 268,
-        "lines_suggested": 1746,
-        "lines_accepted": 468,
-        "active_users": 14
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 201,
-        "acceptances_count": 23,
-        "lines_suggested": 417,
-        "lines_accepted": 56,
-        "active_users": 4
-      },
-      {
-        "language": "cobol",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2310,
-        "acceptances_count": 346,
-        "lines_suggested": 3307,
-        "lines_accepted": 381,
-        "active_users": 19
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 106,
-        "acceptances_count": 30,
-        "lines_suggested": 174,
-        "lines_accepted": 41,
-        "active_users": 5
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 36,
-        "acceptances_count": 14,
-        "lines_suggested": 116,
-        "lines_accepted": 81,
-        "active_users": 5
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 18,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "graphql",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 2,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 8,
-        "lines_suggested": 28,
-        "lines_accepted": 12,
-        "active_users": 4
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 35,
-        "acceptances_count": 1,
-        "lines_suggested": 43,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 65,
-        "acceptances_count": 10,
-        "lines_suggested": 193,
-        "lines_accepted": 102,
-        "active_users": 7
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 14,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 203,
-        "acceptances_count": 6,
-        "lines_suggested": 283,
-        "lines_accepted": 6,
-        "active_users": 5
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 227,
-        "acceptances_count": 54,
-        "lines_suggested": 342,
-        "lines_accepted": 102,
-        "active_users": 7
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 3,
-        "lines_suggested": 59,
-        "lines_accepted": 3,
-        "active_users": 4
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 50,
-        "acceptances_count": 6,
-        "lines_suggested": 71,
-        "lines_accepted": 7,
-        "active_users": 4
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 87,
-        "acceptances_count": 7,
-        "lines_suggested": 188,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "vs-markdown",
-        "editor": "visual_studio",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 25,
-        "acceptances_count": 9,
-        "lines_suggested": 36,
-        "lines_accepted": 15,
-        "active_users": 3
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 25,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 6,
-        "lines_suggested": 76,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 29,
-        "acceptances_count": 7,
-        "lines_suggested": 112,
-        "lines_accepted": 23,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1075,
-        "acceptances_count": 260,
-        "lines_suggested": 6879,
-        "lines_accepted": 559,
-        "active_users": 2
-      },
-      {
-        "language": "web",
-        "editor": "emacs",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-20",
-    "total_suggestions_count": 10657,
-    "total_acceptances_count": 2665,
-    "total_lines_suggested": 26459,
-    "total_lines_accepted": 5054,
-    "total_active_users": 113,
-    "breakdown": [
-      {
-        "language": "env",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 2,
-        "lines_suggested": 30,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 406,
-        "acceptances_count": 190,
-        "lines_suggested": 684,
-        "lines_accepted": 231,
-        "active_users": 6
-      },
-      {
-        "language": "java-properties",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 2,
-        "lines_suggested": 41,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "json5",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 0,
-        "lines_suggested": 40,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 18,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 25,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 67,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "terragrunt",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 4,
-        "lines_suggested": 102,
-        "lines_accepted": 24,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 432,
-        "acceptances_count": 131,
-        "lines_suggested": 939,
-        "lines_accepted": 302,
-        "active_users": 14
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 67,
-        "acceptances_count": 22,
-        "lines_suggested": 118,
-        "lines_accepted": 49,
-        "active_users": 5
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 880,
-        "acceptances_count": 256,
-        "lines_suggested": 2257,
-        "lines_accepted": 805,
-        "active_users": 22
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 211,
-        "acceptances_count": 56,
-        "lines_suggested": 323,
-        "lines_accepted": 68,
-        "active_users": 9
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 129,
-        "acceptances_count": 48,
-        "lines_suggested": 585,
-        "lines_accepted": 139,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 648,
-        "acceptances_count": 208,
-        "lines_suggested": 972,
-        "lines_accepted": 344,
-        "active_users": 14
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 246,
-        "acceptances_count": 84,
-        "lines_suggested": 1059,
-        "lines_accepted": 357,
-        "active_users": 8
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 22,
-        "acceptances_count": 2,
-        "lines_suggested": 28,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 2,
-        "lines_suggested": 6,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 41,
-        "acceptances_count": 18,
-        "lines_suggested": 56,
-        "lines_accepted": 20,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 271,
-        "acceptances_count": 106,
-        "lines_suggested": 408,
-        "lines_accepted": 116,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 243,
-        "acceptances_count": 52,
-        "lines_suggested": 1189,
-        "lines_accepted": 131,
-        "active_users": 4
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 140,
-        "acceptances_count": 30,
-        "lines_suggested": 246,
-        "lines_accepted": 51,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 65,
-        "acceptances_count": 24,
-        "lines_suggested": 149,
-        "lines_accepted": 70,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 4,
-        "lines_suggested": 24,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 745,
-        "acceptances_count": 219,
-        "lines_suggested": 1301,
-        "lines_accepted": 332,
-        "active_users": 12
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 135,
-        "acceptances_count": 24,
-        "lines_suggested": 296,
-        "lines_accepted": 56,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2323,
-        "acceptances_count": 415,
-        "lines_suggested": 3830,
-        "lines_accepted": 541,
-        "active_users": 19
-      },
-      {
-        "language": "tex",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 49,
-        "acceptances_count": 10,
-        "lines_suggested": 102,
-        "lines_accepted": 20,
-        "active_users": 3
-      },
-      {
-        "language": "swift",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 4,
-        "lines_suggested": 10,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 2,
-        "lines_suggested": 19,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 16,
-        "lines_suggested": 325,
-        "lines_accepted": 172,
-        "active_users": 6
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 55,
-        "acceptances_count": 0,
-        "lines_suggested": 105,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 341,
-        "acceptances_count": 76,
-        "lines_suggested": 591,
-        "lines_accepted": 118,
-        "active_users": 12
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 16,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 66,
-        "acceptances_count": 14,
-        "lines_suggested": 93,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 4,
-        "lines_suggested": 44,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "svelte",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 7,
-        "lines_suggested": 48,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 87,
-        "acceptances_count": 11,
-        "lines_suggested": 110,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "vs-markdown",
-        "editor": "visual_studio",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 71,
-        "acceptances_count": 26,
-        "lines_suggested": 155,
-        "lines_accepted": 53,
-        "active_users": 2
-      },
-      {
-        "language": "properties",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 15,
-        "acceptances_count": 3,
-        "lines_suggested": 36,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 42,
-        "acceptances_count": 17,
-        "lines_suggested": 70,
-        "lines_accepted": 37,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 194,
-        "acceptances_count": 24,
-        "lines_suggested": 340,
-        "lines_accepted": 34,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 8,
-        "acceptances_count": 4,
-        "lines_suggested": 8,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 105,
-        "acceptances_count": 41,
-        "lines_suggested": 169,
-        "lines_accepted": 44,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 20,
-        "acceptances_count": 7,
-        "lines_suggested": 37,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 14,
-        "acceptances_count": 9,
-        "lines_suggested": 22,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1875,
-        "acceptances_count": 420,
-        "lines_suggested": 7960,
-        "lines_accepted": 752,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 41,
-        "acceptances_count": 2,
-        "lines_suggested": 98,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 314,
-        "acceptances_count": 52,
-        "lines_suggested": 1137,
-        "lines_accepted": 56,
-        "active_users": 2
-      },
-      {
-        "language": "web",
-        "editor": "emacs",
-        "suggestions_count": 60,
-        "acceptances_count": 14,
-        "lines_suggested": 128,
-        "lines_accepted": 21,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-22",
-    "total_suggestions_count": 6838,
-    "total_acceptances_count": 1744,
-    "total_lines_suggested": 13086,
-    "total_lines_accepted": 3610,
-    "total_active_users": 91,
-    "breakdown": [
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 83,
-        "acceptances_count": 8,
-        "lines_suggested": 112,
-        "lines_accepted": 11,
-        "active_users": 4
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 292,
-        "acceptances_count": 106,
-        "lines_suggested": 511,
-        "lines_accepted": 207,
-        "active_users": 13
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 154,
-        "acceptances_count": 9,
-        "lines_suggested": 455,
-        "lines_accepted": 23,
-        "active_users": 2
-      },
-      {
-        "language": "log",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 35,
-        "acceptances_count": 4,
-        "lines_suggested": 132,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "river",
-        "editor": "vscode",
-        "suggestions_count": 63,
-        "acceptances_count": 3,
-        "lines_suggested": 110,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "rmd",
-        "editor": "vscode",
-        "suggestions_count": 126,
-        "acceptances_count": 28,
-        "lines_suggested": 237,
-        "lines_accepted": 46,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "terragrunt",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 9,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 367,
-        "acceptances_count": 123,
-        "lines_suggested": 669,
-        "lines_accepted": 223,
-        "active_users": 9
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 107,
-        "acceptances_count": 31,
-        "lines_suggested": 172,
-        "lines_accepted": 65,
-        "active_users": 5
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 679,
-        "acceptances_count": 209,
-        "lines_suggested": 1438,
-        "lines_accepted": 676,
-        "active_users": 19
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 164,
-        "acceptances_count": 40,
-        "lines_suggested": 245,
-        "lines_accepted": 92,
-        "active_users": 7
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 744,
-        "acceptances_count": 273,
-        "lines_suggested": 1155,
-        "lines_accepted": 419,
-        "active_users": 12
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 171,
-        "acceptances_count": 92,
-        "lines_suggested": 1101,
-        "lines_accepted": 506,
-        "active_users": 10
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 65,
-        "acceptances_count": 13,
-        "lines_suggested": 88,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 9,
-        "lines_suggested": 22,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 9,
-        "lines_suggested": 37,
-        "lines_accepted": 10,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 49,
-        "acceptances_count": 10,
-        "lines_suggested": 93,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 14,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 52,
-        "acceptances_count": 18,
-        "lines_suggested": 65,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "julia",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 2,
-        "lines_suggested": 12,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 766,
-        "acceptances_count": 165,
-        "lines_suggested": 1532,
-        "lines_accepted": 305,
-        "active_users": 13
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 33,
-        "acceptances_count": 6,
-        "lines_suggested": 79,
-        "lines_accepted": 8,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1399,
-        "acceptances_count": 196,
-        "lines_suggested": 1876,
-        "lines_accepted": 232,
-        "active_users": 10
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 26,
-        "acceptances_count": 20,
-        "lines_suggested": 44,
-        "lines_accepted": 32,
-        "active_users": 4
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 71,
-        "acceptances_count": 16,
-        "lines_suggested": 174,
-        "lines_accepted": 56,
-        "active_users": 5
-      },
-      {
-        "language": "protocol buffer",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 2,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 3,
-        "lines_suggested": 44,
-        "lines_accepted": 38,
-        "active_users": 2
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 65,
-        "acceptances_count": 50,
-        "lines_suggested": 142,
-        "lines_accepted": 55,
-        "active_users": 4
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 2,
-        "lines_suggested": 42,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 52,
-        "acceptances_count": 12,
-        "lines_suggested": 80,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 38,
-        "acceptances_count": 4,
-        "lines_suggested": 45,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 355,
-        "acceptances_count": 82,
-        "lines_suggested": 690,
-        "lines_accepted": 256,
-        "active_users": 12
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 4,
-        "lines_suggested": 43,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 22,
-        "acceptances_count": 2,
-        "lines_suggested": 23,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 12,
-        "lines_suggested": 58,
-        "lines_accepted": 13,
-        "active_users": 4
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 224,
-        "acceptances_count": 24,
-        "lines_suggested": 322,
-        "lines_accepted": 24,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 61,
-        "acceptances_count": 29,
-        "lines_suggested": 90,
-        "lines_accepted": 29,
-        "active_users": 3
-      },
-      {
-        "language": "sql",
-        "editor": "visual_studio",
-        "suggestions_count": 12,
-        "acceptances_count": 11,
-        "lines_suggested": 13,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 6,
-        "lines_suggested": 18,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 16,
-        "acceptances_count": 4,
-        "lines_suggested": 35,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 135,
-        "acceptances_count": 47,
-        "lines_suggested": 542,
-        "lines_accepted": 68,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 12,
-        "acceptances_count": 0,
-        "lines_suggested": 31,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 115,
-        "acceptances_count": 51,
-        "lines_suggested": 287,
-        "lines_accepted": 61,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 42,
-        "acceptances_count": 3,
-        "lines_suggested": 143,
-        "lines_accepted": 3,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-23",
-    "total_suggestions_count": 4728,
-    "total_acceptances_count": 1024,
-    "total_lines_suggested": 7505,
-    "total_lines_accepted": 1416,
-    "total_active_users": 37,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 170,
-        "acceptances_count": 49,
-        "lines_suggested": 451,
-        "lines_accepted": 98,
-        "active_users": 4
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 2,
-        "lines_suggested": 23,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 17,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 33,
-        "acceptances_count": 4,
-        "lines_suggested": 78,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "rmd",
-        "editor": "vscode",
-        "suggestions_count": 142,
-        "acceptances_count": 44,
-        "lines_suggested": 272,
-        "lines_accepted": 50,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 541,
-        "acceptances_count": 156,
-        "lines_suggested": 843,
-        "lines_accepted": 197,
-        "active_users": 6
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 42,
-        "acceptances_count": 16,
-        "lines_suggested": 52,
-        "lines_accepted": 19,
-        "active_users": 3
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 123,
-        "acceptances_count": 34,
-        "lines_suggested": 150,
-        "lines_accepted": 39,
-        "active_users": 6
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 37,
-        "acceptances_count": 16,
-        "lines_suggested": 134,
-        "lines_accepted": 57,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 602,
-        "acceptances_count": 236,
-        "lines_suggested": 775,
-        "lines_accepted": 306,
-        "active_users": 6
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 117,
-        "acceptances_count": 18,
-        "lines_suggested": 261,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 6,
-        "lines_suggested": 23,
-        "lines_accepted": 13,
-        "active_users": 2
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 84,
-        "acceptances_count": 24,
-        "lines_suggested": 153,
-        "lines_accepted": 51,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 138,
-        "acceptances_count": 35,
-        "lines_suggested": 324,
-        "lines_accepted": 51,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 2,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 55,
-        "acceptances_count": 13,
-        "lines_suggested": 91,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 124,
-        "acceptances_count": 39,
-        "lines_suggested": 177,
-        "lines_accepted": 63,
-        "active_users": 7
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 6,
-        "lines_suggested": 144,
-        "lines_accepted": 14,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2108,
-        "acceptances_count": 261,
-        "lines_suggested": 2888,
-        "lines_accepted": 281,
-        "active_users": 5
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 132,
-        "acceptances_count": 30,
-        "lines_suggested": 266,
-        "lines_accepted": 66,
-        "active_users": 5
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 15,
-        "acceptances_count": 2,
-        "lines_suggested": 16,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 16,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 5,
-        "lines_suggested": 32,
-        "lines_accepted": 8,
-        "active_users": 4
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 26,
-        "acceptances_count": 4,
-        "lines_suggested": 34,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 26,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 32,
-        "acceptances_count": 15,
-        "lines_suggested": 66,
-        "lines_accepted": 29,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 4,
-        "lines_suggested": 14,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "php",
-        "editor": "neovim",
-        "suggestions_count": 13,
-        "acceptances_count": 0,
-        "lines_suggested": 28,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 11,
-        "acceptances_count": 1,
-        "lines_suggested": 110,
-        "lines_accepted": 1,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-24",
-    "total_suggestions_count": 5479,
-    "total_acceptances_count": 1482,
-    "total_lines_suggested": 12599,
-    "total_lines_accepted": 2429,
-    "total_active_users": 35,
-    "breakdown": [
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 4,
-        "lines_suggested": 10,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 25,
-        "acceptances_count": 15,
-        "lines_suggested": 26,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "vscode",
-        "suggestions_count": 58,
-        "acceptances_count": 48,
-        "lines_suggested": 196,
-        "lines_accepted": 61,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "river",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 1,
-        "lines_suggested": 47,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "rmd",
-        "editor": "vscode",
-        "suggestions_count": 171,
-        "acceptances_count": 55,
-        "lines_suggested": 325,
-        "lines_accepted": 92,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 21,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 708,
-        "acceptances_count": 272,
-        "lines_suggested": 1193,
-        "lines_accepted": 448,
-        "active_users": 6
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 50,
-        "acceptances_count": 11,
-        "lines_suggested": 83,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 48,
-        "acceptances_count": 16,
-        "lines_suggested": 60,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 143,
-        "acceptances_count": 30,
-        "lines_suggested": 225,
-        "lines_accepted": 46,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 234,
-        "acceptances_count": 51,
-        "lines_suggested": 314,
-        "lines_accepted": 57,
-        "active_users": 6
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 328,
-        "acceptances_count": 95,
-        "lines_suggested": 523,
-        "lines_accepted": 140,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 129,
-        "acceptances_count": 29,
-        "lines_suggested": 252,
-        "lines_accepted": 42,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 9,
-        "lines_suggested": 29,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "julia",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 348,
-        "acceptances_count": 116,
-        "lines_suggested": 598,
-        "lines_accepted": 261,
-        "active_users": 6
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 143,
-        "acceptances_count": 9,
-        "lines_suggested": 276,
-        "lines_accepted": 18,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1169,
-        "acceptances_count": 312,
-        "lines_suggested": 1699,
-        "lines_accepted": 384,
-        "active_users": 3
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 80,
-        "acceptances_count": 17,
-        "lines_suggested": 264,
-        "lines_accepted": 33,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 440,
-        "acceptances_count": 139,
-        "lines_suggested": 1463,
-        "lines_accepted": 340,
-        "active_users": 4
-      },
-      {
-        "language": "vue",
-        "editor": "vscode",
-        "suggestions_count": 39,
-        "acceptances_count": 15,
-        "lines_suggested": 48,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "blade",
-        "editor": "vscode",
-        "suggestions_count": 59,
-        "acceptances_count": 6,
-        "lines_suggested": 90,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 19,
-        "acceptances_count": 3,
-        "lines_suggested": 28,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 58,
-        "acceptances_count": 3,
-        "lines_suggested": 80,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 10,
-        "lines_suggested": 184,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 4,
-        "lines_suggested": 95,
-        "lines_accepted": 6,
-        "active_users": 3
-      },
-      {
-        "language": "editorconfig",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 58,
-        "acceptances_count": 16,
-        "lines_suggested": 73,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 19,
-        "acceptances_count": 8,
-        "lines_suggested": 20,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 10,
-        "acceptances_count": 1,
-        "lines_suggested": 10,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 57,
-        "acceptances_count": 18,
-        "lines_suggested": 66,
-        "lines_accepted": 20,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 24,
-        "acceptances_count": 6,
-        "lines_suggested": 37,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 886,
-        "acceptances_count": 162,
-        "lines_suggested": 4221,
-        "lines_accepted": 330,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-25",
-    "total_suggestions_count": 8703,
-    "total_acceptances_count": 2324,
-    "total_lines_suggested": 14763,
-    "total_lines_accepted": 3990,
-    "total_active_users": 99,
-    "breakdown": [
-      {
-        "language": "fsharp",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 20,
-        "lines_suggested": 132,
-        "lines_accepted": 75,
-        "active_users": 2
-      },
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 41,
-        "acceptances_count": 1,
-        "lines_suggested": 56,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 23,
-        "lines_suggested": 94,
-        "lines_accepted": 31,
-        "active_users": 6
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 3,
-        "lines_suggested": 68,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 100,
-        "acceptances_count": 6,
-        "lines_suggested": 167,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1100,
-        "acceptances_count": 378,
-        "lines_suggested": 1847,
-        "lines_accepted": 710,
-        "active_users": 10
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 239,
-        "acceptances_count": 67,
-        "lines_suggested": 354,
-        "lines_accepted": 93,
-        "active_users": 9
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 616,
-        "acceptances_count": 250,
-        "lines_suggested": 1356,
-        "lines_accepted": 657,
-        "active_users": 19
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 893,
-        "acceptances_count": 272,
-        "lines_suggested": 1146,
-        "lines_accepted": 304,
-        "active_users": 11
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 4,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 317,
-        "acceptances_count": 100,
-        "lines_suggested": 555,
-        "lines_accepted": 163,
-        "active_users": 13
-      },
-      {
-        "language": "c",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 4,
-        "lines_suggested": 15,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 100,
-        "acceptances_count": 58,
-        "lines_suggested": 261,
-        "lines_accepted": 166,
-        "active_users": 5
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 403,
-        "acceptances_count": 157,
-        "lines_suggested": 634,
-        "lines_accepted": 208,
-        "active_users": 5
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 19,
-        "acceptances_count": 14,
-        "lines_suggested": 61,
-        "lines_accepted": 33,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 38,
-        "acceptances_count": 9,
-        "lines_suggested": 50,
-        "lines_accepted": 13,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1389,
-        "acceptances_count": 308,
-        "lines_suggested": 2062,
-        "lines_accepted": 503,
-        "active_users": 13
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 181,
-        "acceptances_count": 15,
-        "lines_suggested": 356,
-        "lines_accepted": 23,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1914,
-        "acceptances_count": 308,
-        "lines_suggested": 2902,
-        "lines_accepted": 374,
-        "active_users": 17
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 125,
-        "acceptances_count": 41,
-        "lines_suggested": 334,
-        "lines_accepted": 116,
-        "active_users": 7
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "csv",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 69,
-        "acceptances_count": 46,
-        "lines_suggested": 93,
-        "lines_accepted": 60,
-        "active_users": 3
-      },
-      {
-        "language": "gradle",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 45,
-        "acceptances_count": 2,
-        "lines_suggested": 108,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 1,
-        "lines_suggested": 14,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 16,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 257,
-        "acceptances_count": 25,
-        "lines_suggested": 477,
-        "lines_accepted": 25,
-        "active_users": 5
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 121,
-        "acceptances_count": 32,
-        "lines_suggested": 236,
-        "lines_accepted": 109,
-        "active_users": 6
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 57,
-        "acceptances_count": 16,
-        "lines_suggested": 81,
-        "lines_accepted": 28,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 26,
-        "acceptances_count": 3,
-        "lines_suggested": 33,
-        "lines_accepted": 5,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 2,
-        "lines_suggested": 10,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 22,
-        "acceptances_count": 6,
-        "lines_suggested": 35,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "visual_studio",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 14,
-        "acceptances_count": 4,
-        "lines_suggested": 36,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 25,
-        "acceptances_count": 4,
-        "lines_suggested": 40,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 93,
-        "acceptances_count": 32,
-        "lines_suggested": 410,
-        "lines_accepted": 82,
-        "active_users": 2
-      },
-      {
-        "language": "sql",
-        "editor": "jetbrains",
-        "suggestions_count": 11,
-        "acceptances_count": 3,
-        "lines_suggested": 12,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 14,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "eruby",
-        "editor": "neovim",
-        "suggestions_count": 15,
-        "acceptances_count": 6,
-        "lines_suggested": 44,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 207,
-        "acceptances_count": 92,
-        "lines_suggested": 524,
-        "lines_accepted": 124,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "neovim",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 17,
-        "acceptances_count": 2,
-        "lines_suggested": 46,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "emacs",
-        "suggestions_count": 11,
-        "acceptances_count": 6,
-        "lines_suggested": 18,
-        "lines_accepted": 9,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-26",
-    "total_suggestions_count": 9119,
-    "total_acceptances_count": 2298,
-    "total_lines_suggested": 16524,
-    "total_lines_accepted": 4566,
-    "total_active_users": 118,
-    "breakdown": [
-      {
-        "language": "concourse-pipeline-yaml",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 2,
-        "lines_suggested": 7,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 26,
-        "lines_suggested": 162,
-        "lines_accepted": 75,
-        "active_users": 2
-      },
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 51,
-        "acceptances_count": 1,
-        "lines_suggested": 61,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "git-rebase",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 224,
-        "acceptances_count": 63,
-        "lines_suggested": 496,
-        "lines_accepted": 169,
-        "active_users": 11
-      },
-      {
-        "language": "go.mod",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 1,
-        "lines_suggested": 15,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 50,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 120,
-        "acceptances_count": 11,
-        "lines_suggested": 161,
-        "lines_accepted": 32,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 11,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 51,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 41,
-        "acceptances_count": 3,
-        "lines_suggested": 47,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 0,
-        "lines_suggested": 17,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 696,
-        "acceptances_count": 172,
-        "lines_suggested": 1170,
-        "lines_accepted": 314,
-        "active_users": 11
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 498,
-        "acceptances_count": 113,
-        "lines_suggested": 801,
-        "lines_accepted": 190,
-        "active_users": 8
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 1103,
-        "acceptances_count": 393,
-        "lines_suggested": 2245,
-        "lines_accepted": 930,
-        "active_users": 30
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 367,
-        "acceptances_count": 71,
-        "lines_suggested": 572,
-        "lines_accepted": 93,
-        "active_users": 11
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 331,
-        "acceptances_count": 106,
-        "lines_suggested": 421,
-        "lines_accepted": 138,
-        "active_users": 12
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 10,
-        "lines_suggested": 20,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 201,
-        "acceptances_count": 105,
-        "lines_suggested": 659,
-        "lines_accepted": 409,
-        "active_users": 12
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 88,
-        "acceptances_count": 28,
-        "lines_suggested": 133,
-        "lines_accepted": 46,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 30,
-        "acceptances_count": 18,
-        "lines_suggested": 88,
-        "lines_accepted": 64,
-        "active_users": 4
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 120,
-        "acceptances_count": 50,
-        "lines_suggested": 172,
-        "lines_accepted": 64,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 2014,
-        "acceptances_count": 545,
-        "lines_suggested": 3360,
-        "lines_accepted": 961,
-        "active_users": 14
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 173,
-        "acceptances_count": 34,
-        "lines_suggested": 299,
-        "lines_accepted": 53,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1174,
-        "acceptances_count": 130,
-        "lines_suggested": 1795,
-        "lines_accepted": 146,
-        "active_users": 15
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 81,
-        "acceptances_count": 25,
-        "lines_suggested": 194,
-        "lines_accepted": 55,
-        "active_users": 11
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 4,
-        "lines_suggested": 38,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "csv",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 33,
-        "lines_suggested": 51,
-        "lines_accepted": 34,
-        "active_users": 2
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 11,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 82,
-        "acceptances_count": 12,
-        "lines_suggested": 192,
-        "lines_accepted": 63,
-        "active_users": 6
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 177,
-        "acceptances_count": 28,
-        "lines_suggested": 253,
-        "lines_accepted": 46,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 103,
-        "acceptances_count": 4,
-        "lines_suggested": 245,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 312,
-        "acceptances_count": 101,
-        "lines_suggested": 547,
-        "lines_accepted": 209,
-        "active_users": 15
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 67,
-        "acceptances_count": 26,
-        "lines_suggested": 136,
-        "lines_accepted": 45,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 138,
-        "acceptances_count": 18,
-        "lines_suggested": 333,
-        "lines_accepted": 24,
-        "active_users": 7
-      },
-      {
-        "language": "editorconfig",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 3,
-        "lines_suggested": 36,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 97,
-        "acceptances_count": 13,
-        "lines_suggested": 200,
-        "lines_accepted": 43,
-        "active_users": 2
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 41,
-        "acceptances_count": 5,
-        "lines_suggested": 46,
-        "lines_accepted": 5,
-        "active_users": 3
-      },
-      {
-        "language": "python",
-        "editor": "visual_studio",
-        "suggestions_count": 4,
-        "acceptances_count": 2,
-        "lines_suggested": 13,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 107,
-        "acceptances_count": 39,
-        "lines_suggested": 398,
-        "lines_accepted": 126,
-        "active_users": 4
-      },
-      {
-        "language": "sql",
-        "editor": "visual_studio",
-        "suggestions_count": 7,
-        "acceptances_count": 5,
-        "lines_suggested": 13,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 32,
-        "acceptances_count": 13,
-        "lines_suggested": 60,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 25,
-        "acceptances_count": 6,
-        "lines_suggested": 63,
-        "lines_accepted": 25,
-        "active_users": 3
-      },
-      {
-        "language": "c",
-        "editor": "jetbrains",
-        "suggestions_count": 165,
-        "acceptances_count": 30,
-        "lines_suggested": 321,
-        "lines_accepted": 62,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 128,
-        "acceptances_count": 32,
-        "lines_suggested": 418,
-        "lines_accepted": 56,
-        "active_users": 3
-      },
-      {
-        "language": "eruby",
-        "editor": "neovim",
-        "suggestions_count": 5,
-        "acceptances_count": 3,
-        "lines_suggested": 9,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 20,
-        "acceptances_count": 6,
-        "lines_suggested": 48,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 28,
-        "lines_accepted": 0,
-        "active_users": 1
-      }
-    ]
-  },
-  {
-    "day": "2024-03-27",
-    "total_suggestions_count": 11575,
-    "total_acceptances_count": 3104,
-    "total_lines_suggested": 25880,
-    "total_lines_accepted": 6335,
-    "total_active_users": 118,
-    "breakdown": [
-      {
-        "language": "csv (pipe)",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "django-html",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "es",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "vscode",
-        "suggestions_count": 125,
-        "acceptances_count": 38,
-        "lines_suggested": 182,
-        "lines_accepted": 43,
-        "active_users": 2
-      },
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 40,
-        "acceptances_count": 2,
-        "lines_suggested": 52,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 83,
-        "acceptances_count": 26,
-        "lines_suggested": 125,
-        "lines_accepted": 39,
-        "active_users": 7
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 2,
-        "lines_suggested": 16,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 100,
-        "acceptances_count": 3,
-        "lines_suggested": 127,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 15,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 52,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 13,
-        "acceptances_count": 1,
-        "lines_suggested": 13,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 3,
-        "lines_suggested": 21,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "restructuredtext",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "river",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 0,
-        "lines_suggested": 42,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ssh_config",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1282,
-        "acceptances_count": 475,
-        "lines_suggested": 2417,
-        "lines_accepted": 976,
-        "active_users": 11
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 260,
-        "acceptances_count": 50,
-        "lines_suggested": 537,
-        "lines_accepted": 77,
-        "active_users": 9
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 744,
-        "acceptances_count": 232,
-        "lines_suggested": 1569,
-        "lines_accepted": 568,
-        "active_users": 25
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 331,
-        "acceptances_count": 82,
-        "lines_suggested": 561,
-        "lines_accepted": 145,
-        "active_users": 10
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 1431,
-        "acceptances_count": 510,
-        "lines_suggested": 2233,
-        "lines_accepted": 911,
-        "active_users": 18
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 218,
-        "acceptances_count": 86,
-        "lines_suggested": 1219,
-        "lines_accepted": 494,
-        "active_users": 14
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 5,
-        "lines_suggested": 12,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 20,
-        "lines_suggested": 87,
-        "lines_accepted": 20,
-        "active_users": 4
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 169,
-        "acceptances_count": 40,
-        "lines_suggested": 369,
-        "lines_accepted": 105,
-        "active_users": 3
-      },
-      {
-        "language": "julia",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 21,
-        "lines_suggested": 73,
-        "lines_accepted": 24,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 15,
-        "acceptances_count": 9,
-        "lines_suggested": 41,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 2021,
-        "acceptances_count": 580,
-        "lines_suggested": 3895,
-        "lines_accepted": 1157,
-        "active_users": 12
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 183,
-        "acceptances_count": 17,
-        "lines_suggested": 317,
-        "lines_accepted": 22,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1394,
-        "acceptances_count": 246,
-        "lines_suggested": 2026,
-        "lines_accepted": 298,
-        "active_users": 21
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 2,
-        "lines_suggested": 19,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 12,
-        "lines_suggested": 64,
-        "lines_accepted": 46,
-        "active_users": 5
-      },
-      {
-        "language": "protocol buffer",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 1,
-        "lines_suggested": 16,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 4,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "vue",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 7,
-        "lines_suggested": 29,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 5,
-        "lines_suggested": 168,
-        "lines_accepted": 9,
-        "active_users": 3
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 73,
-        "acceptances_count": 10,
-        "lines_suggested": 92,
-        "lines_accepted": 10,
-        "active_users": 4
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 117,
-        "acceptances_count": 24,
-        "lines_suggested": 211,
-        "lines_accepted": 36,
-        "active_users": 3
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 76,
-        "acceptances_count": 5,
-        "lines_suggested": 143,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 653,
-        "acceptances_count": 223,
-        "lines_suggested": 1516,
-        "lines_accepted": 599,
-        "active_users": 13
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 92,
-        "acceptances_count": 22,
-        "lines_suggested": 211,
-        "lines_accepted": 32,
-        "active_users": 3
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 22,
-        "acceptances_count": 1,
-        "lines_suggested": 25,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 4,
-        "lines_suggested": 15,
-        "lines_accepted": 5,
-        "active_users": 5
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 85,
-        "acceptances_count": 31,
-        "lines_suggested": 121,
-        "lines_accepted": 43,
-        "active_users": 3
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 21,
-        "acceptances_count": 3,
-        "lines_suggested": 44,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 59,
-        "acceptances_count": 23,
-        "lines_suggested": 139,
-        "lines_accepted": 65,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 142,
-        "acceptances_count": 24,
-        "lines_suggested": 170,
-        "lines_accepted": 24,
-        "active_users": 3
-      },
-      {
-        "language": "c",
-        "editor": "jetbrains",
-        "suggestions_count": 68,
-        "acceptances_count": 10,
-        "lines_suggested": 119,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 70,
-        "acceptances_count": 6,
-        "lines_suggested": 122,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 16,
-        "acceptances_count": 7,
-        "lines_suggested": 82,
-        "lines_accepted": 27,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 72,
-        "acceptances_count": 38,
-        "lines_suggested": 261,
-        "lines_accepted": 80,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "neovim",
-        "suggestions_count": 14,
-        "acceptances_count": 8,
-        "lines_suggested": 21,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1095,
-        "acceptances_count": 171,
-        "lines_suggested": 5886,
-        "lines_accepted": 373,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 54,
-        "acceptances_count": 2,
-        "lines_suggested": 184,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 40,
-        "acceptances_count": 11,
-        "lines_suggested": 101,
-        "lines_accepted": 13,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 17,
-        "acceptances_count": 0,
-        "lines_suggested": 62,
-        "lines_accepted": 0,
-        "active_users": 1
-      }
-    ]
-  },
-  {
-    "day": "2024-03-28",
-    "total_suggestions_count": 9325,
-    "total_acceptances_count": 2149,
-    "total_lines_suggested": 27422,
-    "total_lines_accepted": 4097,
-    "total_active_users": 106,
-    "breakdown": [
-      {
-        "language": "fsharp",
-        "editor": "vscode",
-        "suggestions_count": 45,
-        "acceptances_count": 7,
-        "lines_suggested": 56,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 4,
-        "lines_suggested": 97,
-        "lines_accepted": 4,
-        "active_users": 4
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 252,
-        "acceptances_count": 62,
-        "lines_suggested": 499,
-        "lines_accepted": 124,
-        "active_users": 6
-      },
-      {
-        "language": "java-properties",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 23,
-        "lines_suggested": 52,
-        "lines_accepted": 40,
-        "active_users": 2
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 40,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 51,
-        "acceptances_count": 1,
-        "lines_suggested": 135,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 13,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "tsv",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 401,
-        "acceptances_count": 98,
-        "lines_suggested": 701,
-        "lines_accepted": 163,
-        "active_users": 10
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 99,
-        "acceptances_count": 29,
-        "lines_suggested": 167,
-        "lines_accepted": 45,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 1167,
-        "acceptances_count": 354,
-        "lines_suggested": 2354,
-        "lines_accepted": 827,
-        "active_users": 23
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 306,
-        "acceptances_count": 80,
-        "lines_suggested": 559,
-        "lines_accepted": 115,
-        "active_users": 12
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 5,
-        "lines_suggested": 40,
-        "lines_accepted": 19,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 648,
-        "acceptances_count": 234,
-        "lines_suggested": 1053,
-        "lines_accepted": 415,
-        "active_users": 15
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 117,
-        "acceptances_count": 59,
-        "lines_suggested": 387,
-        "lines_accepted": 207,
-        "active_users": 6
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 70,
-        "acceptances_count": 25,
-        "lines_suggested": 174,
-        "lines_accepted": 44,
-        "active_users": 4
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 83,
-        "acceptances_count": 23,
-        "lines_suggested": 180,
-        "lines_accepted": 60,
-        "active_users": 6
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 3,
-        "lines_suggested": 116,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 22,
-        "acceptances_count": 4,
-        "lines_suggested": 35,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 553,
-        "acceptances_count": 169,
-        "lines_suggested": 1028,
-        "lines_accepted": 349,
-        "active_users": 11
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 52,
-        "acceptances_count": 5,
-        "lines_suggested": 71,
-        "lines_accepted": 7,
-        "active_users": 4
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1466,
-        "acceptances_count": 136,
-        "lines_suggested": 2120,
-        "lines_accepted": 141,
-        "active_users": 21
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 1,
-        "lines_suggested": 20,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 147,
-        "acceptances_count": 37,
-        "lines_suggested": 241,
-        "lines_accepted": 44,
-        "active_users": 11
-      },
-      {
-        "language": "cmake",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 7,
-        "lines_suggested": 11,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 3,
-        "lines_suggested": 69,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "csv",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 39,
-        "acceptances_count": 34,
-        "lines_suggested": 41,
-        "lines_accepted": 34,
-        "active_users": 4
-      },
-      {
-        "language": "gradle",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 21,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 1,
-        "lines_suggested": 20,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 3,
-        "lines_suggested": 6,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 3,
-        "lines_suggested": 25,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 45,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 9,
-        "lines_suggested": 129,
-        "lines_accepted": 9,
-        "active_users": 4
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 191,
-        "acceptances_count": 57,
-        "lines_suggested": 660,
-        "lines_accepted": 216,
-        "active_users": 9
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 94,
-        "acceptances_count": 21,
-        "lines_suggested": 210,
-        "lines_accepted": 32,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 3,
-        "lines_suggested": 18,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 13,
-        "acceptances_count": 4,
-        "lines_suggested": 16,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 89,
-        "acceptances_count": 12,
-        "lines_suggested": 119,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 55,
-        "acceptances_count": 21,
-        "lines_suggested": 63,
-        "lines_accepted": 26,
-        "active_users": 3
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dtd",
-        "editor": "jetbrains",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 30,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 135,
-        "acceptances_count": 16,
-        "lines_suggested": 205,
-        "lines_accepted": 27,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 24,
-        "acceptances_count": 0,
-        "lines_suggested": 25,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 64,
-        "acceptances_count": 14,
-        "lines_suggested": 102,
-        "lines_accepted": 16,
-        "active_users": 3
-      },
-      {
-        "language": "c",
-        "editor": "jetbrains",
-        "suggestions_count": 29,
-        "acceptances_count": 4,
-        "lines_suggested": 36,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 21,
-        "acceptances_count": 10,
-        "lines_suggested": 49,
-        "lines_accepted": 25,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 8,
-        "acceptances_count": 3,
-        "lines_suggested": 11,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 18,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "eruby",
-        "editor": "neovim",
-        "suggestions_count": 13,
-        "acceptances_count": 3,
-        "lines_suggested": 118,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 6,
-        "acceptances_count": 5,
-        "lines_suggested": 11,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 2438,
-        "acceptances_count": 469,
-        "lines_suggested": 13138,
-        "lines_accepted": 815,
-        "active_users": 2
-      },
-      {
-        "language": "css",
-        "editor": "neovim",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 46,
-        "acceptances_count": 8,
-        "lines_suggested": 136,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 194,
-        "acceptances_count": 74,
-        "lines_suggested": 1874,
-        "lines_accepted": 182,
-        "active_users": 3
-      }
-    ]
-  },
-  {
-    "day": "2024-03-30",
-    "total_suggestions_count": 5993,
-    "total_acceptances_count": 1523,
-    "total_lines_suggested": 15527,
-    "total_lines_accepted": 2709,
-    "total_active_users": 33,
-    "breakdown": [
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 1,
-        "lines_suggested": 25,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 238,
-        "acceptances_count": 36,
-        "lines_suggested": 378,
-        "lines_accepted": 72,
-        "active_users": 4
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 9,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 636,
-        "acceptances_count": 196,
-        "lines_suggested": 993,
-        "lines_accepted": 317,
-        "active_users": 3
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 59,
-        "acceptances_count": 8,
-        "lines_suggested": 70,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 347,
-        "acceptances_count": 119,
-        "lines_suggested": 563,
-        "lines_accepted": 292,
-        "active_users": 7
-      },
-      {
-        "language": "lua",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 3,
-        "lines_suggested": 23,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 121,
-        "acceptances_count": 16,
-        "lines_suggested": 139,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 862,
-        "acceptances_count": 321,
-        "lines_suggested": 1696,
-        "lines_accepted": 765,
-        "active_users": 6
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 60,
-        "acceptances_count": 6,
-        "lines_suggested": 87,
-        "lines_accepted": 12,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1681,
-        "acceptances_count": 392,
-        "lines_suggested": 2939,
-        "lines_accepted": 532,
-        "active_users": 6
-      },
-      {
-        "language": "tex",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 118,
-        "acceptances_count": 19,
-        "lines_suggested": 235,
-        "lines_accepted": 29,
-        "active_users": 4
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 3,
-        "lines_suggested": 12,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 1,
-        "lines_suggested": 23,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 2,
-        "lines_suggested": 12,
-        "lines_accepted": 3,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 93,
-        "acceptances_count": 10,
-        "lines_suggested": 225,
-        "lines_accepted": 10,
-        "active_users": 4
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 2,
-        "lines_suggested": 46,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 31,
-        "acceptances_count": 0,
-        "lines_suggested": 35,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 129,
-        "acceptances_count": 75,
-        "lines_suggested": 184,
-        "lines_accepted": 99,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 20,
-        "acceptances_count": 11,
-        "lines_suggested": 41,
-        "lines_accepted": 25,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1380,
-        "acceptances_count": 294,
-        "lines_suggested": 7287,
-        "lines_accepted": 506,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 49,
-        "acceptances_count": 3,
-        "lines_suggested": 291,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 13,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 47,
-        "acceptances_count": 1,
-        "lines_suggested": 162,
-        "lines_accepted": 1,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-03-31",
-    "total_suggestions_count": 6995,
-    "total_acceptances_count": 1859,
-    "total_lines_suggested": 17328,
-    "total_lines_accepted": 3044,
-    "total_active_users": 35,
-    "breakdown": [
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 2,
-        "lines_suggested": 21,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 71,
-        "acceptances_count": 25,
-        "lines_suggested": 156,
-        "lines_accepted": 49,
-        "active_users": 3
-      },
-      {
-        "language": "gotemplate",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 2,
-        "lines_suggested": 16,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 189,
-        "acceptances_count": 15,
-        "lines_suggested": 387,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "sas",
-        "editor": "vscode",
-        "suggestions_count": 71,
-        "acceptances_count": 14,
-        "lines_suggested": 116,
-        "lines_accepted": 17,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 223,
-        "acceptances_count": 72,
-        "lines_suggested": 394,
-        "lines_accepted": 108,
-        "active_users": 5
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 82,
-        "acceptances_count": 5,
-        "lines_suggested": 102,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 759,
-        "acceptances_count": 256,
-        "lines_suggested": 1614,
-        "lines_accepted": 385,
-        "active_users": 9
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 63,
-        "acceptances_count": 32,
-        "lines_suggested": 100,
-        "lines_accepted": 32,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 413,
-        "acceptances_count": 106,
-        "lines_suggested": 650,
-        "lines_accepted": 159,
-        "active_users": 6
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "clojure",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 59,
-        "acceptances_count": 15,
-        "lines_suggested": 73,
-        "lines_accepted": 19,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1077,
-        "acceptances_count": 389,
-        "lines_suggested": 2150,
-        "lines_accepted": 807,
-        "active_users": 9
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 55,
-        "acceptances_count": 4,
-        "lines_suggested": 116,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1644,
-        "acceptances_count": 402,
-        "lines_suggested": 2405,
-        "lines_accepted": 428,
-        "active_users": 6
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 119,
-        "acceptances_count": 11,
-        "lines_suggested": 327,
-        "lines_accepted": 17,
-        "active_users": 4
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 2,
-        "lines_suggested": 12,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 5,
-        "lines_suggested": 67,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "vscode",
-        "suggestions_count": 28,
-        "acceptances_count": 1,
-        "lines_suggested": 45,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 0,
-        "lines_suggested": 104,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 125,
-        "acceptances_count": 34,
-        "lines_suggested": 215,
-        "lines_accepted": 69,
-        "active_users": 3
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 1,
-        "lines_suggested": 16,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 2,
-        "lines_suggested": 2,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 5,
-        "lines_suggested": 26,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 31,
-        "acceptances_count": 9,
-        "lines_suggested": 102,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 379,
-        "acceptances_count": 94,
-        "lines_suggested": 1166,
-        "lines_accepted": 190,
-        "active_users": 3
-      },
-      {
-        "language": "vim",
-        "editor": "neovim",
-        "suggestions_count": 11,
-        "acceptances_count": 2,
-        "lines_suggested": 27,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "lua",
-        "editor": "neovim",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 99,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1215,
-        "acceptances_count": 282,
-        "lines_suggested": 5637,
-        "lines_accepted": 585,
-        "active_users": 2
-      },
-      {
-        "language": "css",
-        "editor": "neovim",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 50,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 55,
-        "acceptances_count": 17,
-        "lines_suggested": 174,
-        "lines_accepted": 29,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 153,
-        "acceptances_count": 55,
-        "lines_suggested": 946,
-        "lines_accepted": 79,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-01",
-    "total_suggestions_count": 6819,
-    "total_acceptances_count": 1815,
-    "total_lines_suggested": 29475,
-    "total_lines_accepted": 3169,
-    "total_active_users": 70,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 434,
-        "acceptances_count": 122,
-        "lines_suggested": 750,
-        "lines_accepted": 185,
-        "active_users": 5
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 1,
-        "lines_suggested": 11,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "jade",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "mermaid",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "objective-cpp",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 11,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 386,
-        "acceptances_count": 95,
-        "lines_suggested": 565,
-        "lines_accepted": 164,
-        "active_users": 9
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 47,
-        "acceptances_count": 11,
-        "lines_suggested": 80,
-        "lines_accepted": 14,
-        "active_users": 5
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 368,
-        "acceptances_count": 99,
-        "lines_suggested": 721,
-        "lines_accepted": 209,
-        "active_users": 15
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 471,
-        "acceptances_count": 120,
-        "lines_suggested": 648,
-        "lines_accepted": 169,
-        "active_users": 9
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 309,
-        "acceptances_count": 111,
-        "lines_suggested": 591,
-        "lines_accepted": 217,
-        "active_users": 7
-      },
-      {
-        "language": "perl",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 0,
-        "lines_suggested": 24,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 2,
-        "lines_suggested": 50,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "clojure",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 259,
-        "acceptances_count": 76,
-        "lines_suggested": 341,
-        "lines_accepted": 92,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 3,
-        "lines_suggested": 73,
-        "lines_accepted": 6,
-        "active_users": 3
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 47,
-        "acceptances_count": 6,
-        "lines_suggested": 104,
-        "lines_accepted": 14,
-        "active_users": 3
-      },
-      {
-        "language": "julia",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1391,
-        "acceptances_count": 411,
-        "lines_suggested": 2420,
-        "lines_accepted": 742,
-        "active_users": 13
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 4,
-        "lines_suggested": 43,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1326,
-        "acceptances_count": 234,
-        "lines_suggested": 1936,
-        "lines_accepted": 262,
-        "active_users": 8
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 58,
-        "acceptances_count": 7,
-        "lines_suggested": 199,
-        "lines_accepted": 29,
-        "active_users": 4
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 77,
-        "acceptances_count": 35,
-        "lines_suggested": 614,
-        "lines_accepted": 211,
-        "active_users": 3
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 21,
-        "lines_suggested": 71,
-        "lines_accepted": 22,
-        "active_users": 3
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 42,
-        "acceptances_count": 8,
-        "lines_suggested": 69,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 64,
-        "acceptances_count": 14,
-        "lines_suggested": 99,
-        "lines_accepted": 14,
-        "active_users": 4
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 7,
-        "lines_suggested": 15664,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 303,
-        "acceptances_count": 91,
-        "lines_suggested": 557,
-        "lines_accepted": 145,
-        "active_users": 11
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 5,
-        "lines_suggested": 31,
-        "lines_accepted": 5,
-        "active_users": 4
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 9,
-        "lines_suggested": 73,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "code++.ini",
-        "editor": "visual_studio",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 29,
-        "acceptances_count": 3,
-        "lines_suggested": 248,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 95,
-        "acceptances_count": 63,
-        "lines_suggested": 99,
-        "lines_accepted": 66,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 2,
-        "lines_suggested": 4,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 409,
-        "acceptances_count": 113,
-        "lines_suggested": 1278,
-        "lines_accepted": 229,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 73,
-        "acceptances_count": 21,
-        "lines_suggested": 253,
-        "lines_accepted": 32,
-        "active_users": 2
-      },
-      {
-        "language": "css",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 5,
-        "acceptances_count": 4,
-        "lines_suggested": 5,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 88,
-        "acceptances_count": 20,
-        "lines_suggested": 380,
-        "lines_accepted": 60,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 10,
-        "acceptances_count": 6,
-        "lines_suggested": 14,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 208,
-        "acceptances_count": 87,
-        "lines_suggested": 1398,
-        "lines_accepted": 230,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-02",
-    "total_suggestions_count": 8476,
-    "total_acceptances_count": 2237,
-    "total_lines_suggested": 14464,
-    "total_lines_accepted": 3768,
-    "total_active_users": 106,
-    "breakdown": [
-      {
-        "language": "aspnetcorerazor",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 3,
-        "lines_suggested": 27,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 17,
-        "lines_suggested": 119,
-        "lines_accepted": 21,
-        "active_users": 4
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1726,
-        "acceptances_count": 535,
-        "lines_suggested": 2611,
-        "lines_accepted": 843,
-        "active_users": 19
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 64,
-        "acceptances_count": 40,
-        "lines_suggested": 86,
-        "lines_accepted": 54,
-        "active_users": 3
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 410,
-        "acceptances_count": 136,
-        "lines_suggested": 916,
-        "lines_accepted": 305,
-        "active_users": 20
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 623,
-        "acceptances_count": 198,
-        "lines_suggested": 896,
-        "lines_accepted": 226,
-        "active_users": 14
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 568,
-        "acceptances_count": 203,
-        "lines_suggested": 869,
-        "lines_accepted": 327,
-        "active_users": 15
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 66,
-        "acceptances_count": 20,
-        "lines_suggested": 394,
-        "lines_accepted": 196,
-        "active_users": 6
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 192,
-        "acceptances_count": 52,
-        "lines_suggested": 337,
-        "lines_accepted": 75,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 11,
-        "lines_suggested": 42,
-        "lines_accepted": 20,
-        "active_users": 4
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 13,
-        "lines_suggested": 340,
-        "lines_accepted": 31,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 78,
-        "acceptances_count": 12,
-        "lines_suggested": 99,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1293,
-        "acceptances_count": 345,
-        "lines_suggested": 2094,
-        "lines_accepted": 602,
-        "active_users": 20
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 98,
-        "acceptances_count": 14,
-        "lines_suggested": 248,
-        "lines_accepted": 42,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1904,
-        "acceptances_count": 276,
-        "lines_suggested": 2753,
-        "lines_accepted": 316,
-        "active_users": 16
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 2,
-        "lines_suggested": 46,
-        "lines_accepted": 17,
-        "active_users": 3
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 100,
-        "acceptances_count": 15,
-        "lines_suggested": 238,
-        "lines_accepted": 28,
-        "active_users": 6
-      },
-      {
-        "language": "protocol buffer",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 81,
-        "acceptances_count": 23,
-        "lines_suggested": 246,
-        "lines_accepted": 75,
-        "active_users": 3
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 52,
-        "acceptances_count": 15,
-        "lines_suggested": 64,
-        "lines_accepted": 15,
-        "active_users": 4
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 26,
-        "acceptances_count": 7,
-        "lines_suggested": 40,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 18,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 82,
-        "acceptances_count": 21,
-        "lines_suggested": 190,
-        "lines_accepted": 55,
-        "active_users": 7
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 2,
-        "lines_suggested": 44,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "toml",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 0,
-        "lines_suggested": 215,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 387,
-        "acceptances_count": 108,
-        "lines_suggested": 605,
-        "lines_accepted": 182,
-        "active_users": 10
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 19,
-        "acceptances_count": 4,
-        "lines_suggested": 34,
-        "lines_accepted": 14,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 0,
-        "lines_suggested": 20,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 2,
-        "lines_suggested": 8,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 5,
-        "lines_suggested": 49,
-        "lines_accepted": 27,
-        "active_users": 2
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 8,
-        "lines_suggested": 30,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 13,
-        "acceptances_count": 5,
-        "lines_suggested": 13,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 129,
-        "acceptances_count": 85,
-        "lines_suggested": 247,
-        "lines_accepted": 133,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "visual_studio",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 37,
-        "acceptances_count": 7,
-        "lines_suggested": 57,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 38,
-        "acceptances_count": 4,
-        "lines_suggested": 102,
-        "lines_accepted": 7,
-        "active_users": 3
-      },
-      {
-        "language": "go",
-        "editor": "jetbrains",
-        "suggestions_count": 7,
-        "acceptances_count": 3,
-        "lines_suggested": 27,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 34,
-        "acceptances_count": 10,
-        "lines_suggested": 106,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "jetbrains",
-        "suggestions_count": 15,
-        "acceptances_count": 2,
-        "lines_suggested": 29,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 33,
-        "acceptances_count": 22,
-        "lines_suggested": 70,
-        "lines_accepted": 50,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "vim",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "zsh",
-        "editor": "neovim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 20,
-        "acceptances_count": 9,
-        "lines_suggested": 49,
-        "lines_accepted": 9,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-03",
-    "total_suggestions_count": 8943,
-    "total_acceptances_count": 2240,
-    "total_lines_suggested": 19976,
-    "total_lines_accepted": 4386,
-    "total_active_users": 101,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 38,
-        "acceptances_count": 0,
-        "lines_suggested": 47,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 196,
-        "acceptances_count": 53,
-        "lines_suggested": 346,
-        "lines_accepted": 95,
-        "active_users": 11
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "puppet",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 3,
-        "lines_suggested": 24,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ssh_config",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1190,
-        "acceptances_count": 252,
-        "lines_suggested": 1817,
-        "lines_accepted": 351,
-        "active_users": 11
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 143,
-        "acceptances_count": 58,
-        "lines_suggested": 183,
-        "lines_accepted": 70,
-        "active_users": 5
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 755,
-        "acceptances_count": 240,
-        "lines_suggested": 1589,
-        "lines_accepted": 484,
-        "active_users": 21
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 290,
-        "acceptances_count": 63,
-        "lines_suggested": 405,
-        "lines_accepted": 133,
-        "active_users": 10
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 442,
-        "acceptances_count": 191,
-        "lines_suggested": 733,
-        "lines_accepted": 351,
-        "active_users": 13
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 6,
-        "lines_suggested": 11,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 263,
-        "acceptances_count": 145,
-        "lines_suggested": 1006,
-        "lines_accepted": 408,
-        "active_users": 10
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 640,
-        "acceptances_count": 144,
-        "lines_suggested": 1085,
-        "lines_accepted": 231,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 176,
-        "acceptances_count": 89,
-        "lines_suggested": 469,
-        "lines_accepted": 182,
-        "active_users": 5
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 196,
-        "acceptances_count": 41,
-        "lines_suggested": 373,
-        "lines_accepted": 97,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1171,
-        "acceptances_count": 344,
-        "lines_suggested": 2123,
-        "lines_accepted": 692,
-        "active_users": 14
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 37,
-        "acceptances_count": 7,
-        "lines_suggested": 92,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1260,
-        "acceptances_count": 192,
-        "lines_suggested": 1545,
-        "lines_accepted": 204,
-        "active_users": 17
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 12,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "swift",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 60,
-        "acceptances_count": 10,
-        "lines_suggested": 124,
-        "lines_accepted": 43,
-        "active_users": 5
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 281,
-        "acceptances_count": 40,
-        "lines_suggested": 1231,
-        "lines_accepted": 124,
-        "active_users": 2
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 15,
-        "lines_suggested": 17,
-        "lines_accepted": 15,
-        "active_users": 3
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 30,
-        "acceptances_count": 6,
-        "lines_suggested": 38,
-        "lines_accepted": 6,
-        "active_users": 4
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 79,
-        "acceptances_count": 6,
-        "lines_suggested": 198,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 120,
-        "acceptances_count": 12,
-        "lines_suggested": 242,
-        "lines_accepted": 19,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 188,
-        "acceptances_count": 38,
-        "lines_suggested": 274,
-        "lines_accepted": 63,
-        "active_users": 8
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 2,
-        "lines_suggested": 101,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 6,
-        "lines_suggested": 18,
-        "lines_accepted": 6,
-        "active_users": 5
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 1,
-        "lines_suggested": 22,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 69,
-        "acceptances_count": 33,
-        "lines_suggested": 333,
-        "lines_accepted": 255,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 67,
-        "acceptances_count": 20,
-        "lines_suggested": 147,
-        "lines_accepted": 23,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 54,
-        "acceptances_count": 16,
-        "lines_suggested": 123,
-        "lines_accepted": 61,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 27,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "perl",
-        "editor": "jetbrains",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 328,
-        "acceptances_count": 69,
-        "lines_suggested": 803,
-        "lines_accepted": 116,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 31,
-        "acceptances_count": 7,
-        "lines_suggested": 112,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 121,
-        "acceptances_count": 12,
-        "lines_suggested": 170,
-        "lines_accepted": 17,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 494,
-        "acceptances_count": 101,
-        "lines_suggested": 3844,
-        "lines_accepted": 258,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 42,
-        "acceptances_count": 12,
-        "lines_suggested": 145,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 35,
-        "acceptances_count": 0,
-        "lines_suggested": 94,
-        "lines_accepted": 0,
-        "active_users": 1
-      }
-    ]
-  },
-  {
-    "day": "2024-04-04",
-    "total_suggestions_count": 12821,
-    "total_acceptances_count": 3067,
-    "total_lines_suggested": 27008,
-    "total_lines_accepted": 5982,
-    "total_active_users": 118,
-    "breakdown": [
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 80,
-        "acceptances_count": 2,
-        "lines_suggested": 95,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 222,
-        "acceptances_count": 52,
-        "lines_suggested": 365,
-        "lines_accepted": 105,
-        "active_users": 10
-      },
-      {
-        "language": "html.erb",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 6,
-        "lines_suggested": 38,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "puppet",
-        "editor": "vscode",
-        "suggestions_count": 19,
-        "acceptances_count": 4,
-        "lines_suggested": 77,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 73,
-        "acceptances_count": 11,
-        "lines_suggested": 172,
-        "lines_accepted": 24,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 1009,
-        "acceptances_count": 338,
-        "lines_suggested": 1573,
-        "lines_accepted": 510,
-        "active_users": 8
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 158,
-        "acceptances_count": 36,
-        "lines_suggested": 231,
-        "lines_accepted": 52,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 834,
-        "acceptances_count": 292,
-        "lines_suggested": 1853,
-        "lines_accepted": 836,
-        "active_users": 26
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 370,
-        "acceptances_count": 88,
-        "lines_suggested": 458,
-        "lines_accepted": 93,
-        "active_users": 10
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 1034,
-        "acceptances_count": 394,
-        "lines_suggested": 1498,
-        "lines_accepted": 609,
-        "active_users": 17
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 160,
-        "acceptances_count": 81,
-        "lines_suggested": 1433,
-        "lines_accepted": 517,
-        "active_users": 9
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 2,
-        "lines_suggested": 33,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 389,
-        "acceptances_count": 83,
-        "lines_suggested": 714,
-        "lines_accepted": 137,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 121,
-        "acceptances_count": 34,
-        "lines_suggested": 356,
-        "lines_accepted": 94,
-        "active_users": 5
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 99,
-        "acceptances_count": 16,
-        "lines_suggested": 404,
-        "lines_accepted": 36,
-        "active_users": 3
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 162,
-        "acceptances_count": 28,
-        "lines_suggested": 212,
-        "lines_accepted": 33,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 2424,
-        "acceptances_count": 613,
-        "lines_suggested": 4391,
-        "lines_accepted": 1119,
-        "active_users": 17
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 58,
-        "acceptances_count": 6,
-        "lines_suggested": 117,
-        "lines_accepted": 14,
-        "active_users": 4
-      },
-      {
-        "language": "cobol",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 3,
-        "lines_suggested": 8,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2432,
-        "acceptances_count": 247,
-        "lines_suggested": 3239,
-        "lines_accepted": 313,
-        "active_users": 19
-      },
-      {
-        "language": "tex",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 7,
-        "lines_suggested": 50,
-        "lines_accepted": 24,
-        "active_users": 4
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 51,
-        "acceptances_count": 13,
-        "lines_suggested": 224,
-        "lines_accepted": 53,
-        "active_users": 6
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 167,
-        "acceptances_count": 39,
-        "lines_suggested": 371,
-        "lines_accepted": 68,
-        "active_users": 5
-      },
-      {
-        "language": "vue",
-        "editor": "vscode",
-        "suggestions_count": 90,
-        "acceptances_count": 14,
-        "lines_suggested": 241,
-        "lines_accepted": 34,
-        "active_users": 2
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 38,
-        "acceptances_count": 22,
-        "lines_suggested": 46,
-        "lines_accepted": 24,
-        "active_users": 3
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 110,
-        "acceptances_count": 39,
-        "lines_suggested": 174,
-        "lines_accepted": 46,
-        "active_users": 4
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 53,
-        "acceptances_count": 2,
-        "lines_suggested": 119,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 134,
-        "acceptances_count": 18,
-        "lines_suggested": 353,
-        "lines_accepted": 18,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 314,
-        "acceptances_count": 90,
-        "lines_suggested": 552,
-        "lines_accepted": 150,
-        "active_users": 9
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 31,
-        "acceptances_count": 0,
-        "lines_suggested": 46,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 4,
-        "lines_suggested": 10,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 5,
-        "lines_suggested": 18,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 65,
-        "acceptances_count": 4,
-        "lines_suggested": 84,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 26,
-        "acceptances_count": 11,
-        "lines_suggested": 28,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "vs-markdown",
-        "editor": "visual_studio",
-        "suggestions_count": 57,
-        "acceptances_count": 17,
-        "lines_suggested": 57,
-        "lines_accepted": 17,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 29,
-        "acceptances_count": 12,
-        "lines_suggested": 55,
-        "lines_accepted": 34,
-        "active_users": 5
-      },
-      {
-        "language": "sql",
-        "editor": "visual_studio",
-        "suggestions_count": 7,
-        "acceptances_count": 5,
-        "lines_suggested": 8,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "msbuild",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "jetbrains",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 16,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 361,
-        "acceptances_count": 74,
-        "lines_suggested": 550,
-        "lines_accepted": 84,
-        "active_users": 3
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 12,
-        "acceptances_count": 4,
-        "lines_suggested": 22,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 2,
-        "lines_suggested": 33,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "jetbrains",
-        "suggestions_count": 142,
-        "acceptances_count": 61,
-        "lines_suggested": 177,
-        "lines_accepted": 73,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 27,
-        "acceptances_count": 12,
-        "lines_suggested": 92,
-        "lines_accepted": 72,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "jetbrains",
-        "suggestions_count": 26,
-        "acceptances_count": 4,
-        "lines_suggested": 27,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "sql",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 3,
-        "lines_suggested": 7,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "conf",
-        "editor": "vim",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 1208,
-        "acceptances_count": 260,
-        "lines_suggested": 6096,
-        "lines_accepted": 687,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 39,
-        "acceptances_count": 9,
-        "lines_suggested": 197,
-        "lines_accepted": 20,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 14,
-        "acceptances_count": 0,
-        "lines_suggested": 32,
-        "lines_accepted": 0,
-        "active_users": 1
-      }
-    ]
-  },
-  {
-    "day": "2024-04-06",
-    "total_suggestions_count": 5345,
-    "total_acceptances_count": 1476,
-    "total_lines_suggested": 10927,
-    "total_lines_accepted": 2433,
-    "total_active_users": 32,
-    "breakdown": [
-      {
-        "language": "aspnetcorerazor",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 0,
-        "lines_suggested": 16,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "jade",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 0,
-        "lines_suggested": 18,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 253,
-        "acceptances_count": 69,
-        "lines_suggested": 401,
-        "lines_accepted": 100,
-        "active_users": 5
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 2,
-        "lines_suggested": 17,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 362,
-        "acceptances_count": 120,
-        "lines_suggested": 621,
-        "lines_accepted": 213,
-        "active_users": 8
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 743,
-        "acceptances_count": 330,
-        "lines_suggested": 1162,
-        "lines_accepted": 590,
-        "active_users": 9
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 93,
-        "acceptances_count": 52,
-        "lines_suggested": 272,
-        "lines_accepted": 137,
-        "active_users": 2
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 8,
-        "lines_suggested": 160,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 112,
-        "acceptances_count": 42,
-        "lines_suggested": 151,
-        "lines_accepted": 50,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 47,
-        "acceptances_count": 15,
-        "lines_suggested": 68,
-        "lines_accepted": 26,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 664,
-        "acceptances_count": 192,
-        "lines_suggested": 1062,
-        "lines_accepted": 340,
-        "active_users": 7
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 89,
-        "acceptances_count": 10,
-        "lines_suggested": 179,
-        "lines_accepted": 23,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1997,
-        "acceptances_count": 431,
-        "lines_suggested": 3031,
-        "lines_accepted": 479,
-        "active_users": 5
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 10,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "nix",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 1,
-        "lines_suggested": 28,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 2,
-        "lines_suggested": 92,
-        "lines_accepted": 8,
-        "active_users": 3
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 13,
-        "acceptances_count": 2,
-        "lines_suggested": 16,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 276,
-        "acceptances_count": 55,
-        "lines_suggested": 579,
-        "lines_accepted": 86,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 5,
-        "lines_suggested": 28,
-        "lines_accepted": 15,
-        "active_users": 3
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 37,
-        "acceptances_count": 10,
-        "lines_suggested": 62,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 56,
-        "acceptances_count": 21,
-        "lines_suggested": 97,
-        "lines_accepted": 40,
-        "active_users": 3
-      },
-      {
-        "language": "json",
-        "editor": "visual_studio",
-        "suggestions_count": 8,
-        "acceptances_count": 3,
-        "lines_suggested": 8,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 17,
-        "acceptances_count": 1,
-        "lines_suggested": 37,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 62,
-        "acceptances_count": 8,
-        "lines_suggested": 113,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "sshconfig",
-        "editor": "vim",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 30,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 245,
-        "acceptances_count": 64,
-        "lines_suggested": 1624,
-        "lines_accepted": 161,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 62,
-        "acceptances_count": 31,
-        "lines_suggested": 1001,
-        "lines_accepted": 105,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-07",
-    "total_suggestions_count": 6539,
-    "total_acceptances_count": 1901,
-    "total_lines_suggested": 13533,
-    "total_lines_accepted": 3611,
-    "total_active_users": 38,
-    "breakdown": [
-      {
-        "language": "fsharp",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 34,
-        "lines_suggested": 199,
-        "lines_accepted": 61,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 1,
-        "lines_suggested": 10,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 5,
-        "lines_suggested": 31,
-        "lines_accepted": 21,
-        "active_users": 2
-      },
-      {
-        "language": "jade",
-        "editor": "vscode",
-        "suggestions_count": 135,
-        "acceptances_count": 56,
-        "lines_suggested": 235,
-        "lines_accepted": 103,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 31,
-        "acceptances_count": 0,
-        "lines_suggested": 80,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "rmd",
-        "editor": "vscode",
-        "suggestions_count": 38,
-        "acceptances_count": 1,
-        "lines_suggested": 44,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 675,
-        "acceptances_count": 196,
-        "lines_suggested": 1127,
-        "lines_accepted": 343,
-        "active_users": 9
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 397,
-        "acceptances_count": 122,
-        "lines_suggested": 599,
-        "lines_accepted": 212,
-        "active_users": 5
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 1173,
-        "acceptances_count": 410,
-        "lines_suggested": 1907,
-        "lines_accepted": 712,
-        "active_users": 6
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 110,
-        "acceptances_count": 24,
-        "lines_suggested": 431,
-        "lines_accepted": 151,
-        "active_users": 3
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 14,
-        "acceptances_count": 10,
-        "lines_suggested": 14,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 57,
-        "acceptances_count": 1,
-        "lines_suggested": 157,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 36,
-        "acceptances_count": 8,
-        "lines_suggested": 43,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 188,
-        "acceptances_count": 76,
-        "lines_suggested": 450,
-        "lines_accepted": 112,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 25,
-        "acceptances_count": 9,
-        "lines_suggested": 75,
-        "lines_accepted": 31,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 411,
-        "acceptances_count": 129,
-        "lines_suggested": 1053,
-        "lines_accepted": 393,
-        "active_users": 6
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 76,
-        "acceptances_count": 12,
-        "lines_suggested": 191,
-        "lines_accepted": 25,
-        "active_users": 5
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1697,
-        "acceptances_count": 373,
-        "lines_suggested": 2804,
-        "lines_accepted": 453,
-        "active_users": 5
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 39,
-        "acceptances_count": 19,
-        "lines_suggested": 42,
-        "lines_accepted": 19,
-        "active_users": 3
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 26,
-        "acceptances_count": 0,
-        "lines_suggested": 29,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 90,
-        "acceptances_count": 16,
-        "lines_suggested": 149,
-        "lines_accepted": 28,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 146,
-        "acceptances_count": 17,
-        "lines_suggested": 212,
-        "lines_accepted": 17,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 53,
-        "acceptances_count": 16,
-        "lines_suggested": 174,
-        "lines_accepted": 31,
-        "active_users": 3
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 77,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 4,
-        "lines_suggested": 30,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 67,
-        "acceptances_count": 21,
-        "lines_suggested": 195,
-        "lines_accepted": 73,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "visual_studio",
-        "suggestions_count": 41,
-        "acceptances_count": 8,
-        "lines_suggested": 132,
-        "lines_accepted": 17,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "visual_studio",
-        "suggestions_count": 104,
-        "acceptances_count": 26,
-        "lines_suggested": 125,
-        "lines_accepted": 39,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 97,
-        "acceptances_count": 30,
-        "lines_suggested": 160,
-        "lines_accepted": 52,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 34,
-        "acceptances_count": 12,
-        "lines_suggested": 54,
-        "lines_accepted": 26,
-        "active_users": 2
-      },
-      {
-        "language": "plm",
-        "editor": "vim",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sshconfig",
-        "editor": "vim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 15,
-        "acceptances_count": 2,
-        "lines_suggested": 29,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 278,
-        "acceptances_count": 79,
-        "lines_suggested": 1108,
-        "lines_accepted": 207,
-        "active_users": 2
-      },
-      {
-        "language": "css",
-        "editor": "neovim",
-        "suggestions_count": 27,
-        "acceptances_count": 4,
-        "lines_suggested": 144,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "neovim",
-        "suggestions_count": 318,
-        "acceptances_count": 179,
-        "lines_suggested": 1407,
-        "lines_accepted": 448,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-08",
-    "total_suggestions_count": 8587,
-    "total_acceptances_count": 2380,
-    "total_lines_suggested": 16254,
-    "total_lines_accepted": 4618,
-    "total_active_users": 96,
-    "breakdown": [
-      {
-        "language": "django-html",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 11,
-        "lines_accepted": 9,
-        "active_users": 2
-      },
-      {
-        "language": "django-txt",
-        "editor": "vscode",
-        "suggestions_count": 20,
-        "acceptances_count": 10,
-        "lines_suggested": 24,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "dockercompose",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 2,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 27,
-        "acceptances_count": 2,
-        "lines_suggested": 30,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 516,
-        "acceptances_count": 195,
-        "lines_suggested": 1084,
-        "lines_accepted": 370,
-        "active_users": 8
-      },
-      {
-        "language": "helm",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "html.erb",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 10,
-        "lines_suggested": 132,
-        "lines_accepted": 34,
-        "active_users": 2
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 18,
-        "lines_suggested": 38,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 8,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 1,
-        "lines_suggested": 31,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 525,
-        "acceptances_count": 130,
-        "lines_suggested": 817,
-        "lines_accepted": 174,
-        "active_users": 12
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 21,
-        "lines_suggested": 112,
-        "lines_accepted": 42,
-        "active_users": 4
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 628,
-        "acceptances_count": 200,
-        "lines_suggested": 1330,
-        "lines_accepted": 521,
-        "active_users": 15
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 308,
-        "acceptances_count": 106,
-        "lines_suggested": 447,
-        "lines_accepted": 114,
-        "active_users": 8
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 908,
-        "acceptances_count": 343,
-        "lines_suggested": 1355,
-        "lines_accepted": 536,
-        "active_users": 14
-      },
-      {
-        "language": "perl",
-        "editor": "vscode",
-        "suggestions_count": 13,
-        "acceptances_count": 1,
-        "lines_suggested": 15,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 207,
-        "acceptances_count": 104,
-        "lines_suggested": 403,
-        "lines_accepted": 257,
-        "active_users": 10
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 37,
-        "acceptances_count": 14,
-        "lines_suggested": 63,
-        "lines_accepted": 22,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 103,
-        "acceptances_count": 25,
-        "lines_suggested": 422,
-        "lines_accepted": 40,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 30,
-        "lines_suggested": 260,
-        "lines_accepted": 153,
-        "active_users": 4
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 24,
-        "acceptances_count": 3,
-        "lines_suggested": 59,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 0,
-        "lines_suggested": 24,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 5,
-        "lines_suggested": 47,
-        "lines_accepted": 27,
-        "active_users": 3
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1525,
-        "acceptances_count": 413,
-        "lines_suggested": 2486,
-        "lines_accepted": 808,
-        "active_users": 19
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 36,
-        "acceptances_count": 16,
-        "lines_suggested": 71,
-        "lines_accepted": 36,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1642,
-        "acceptances_count": 319,
-        "lines_suggested": 2140,
-        "lines_accepted": 367,
-        "active_users": 14
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 5,
-        "lines_suggested": 58,
-        "lines_accepted": 22,
-        "active_users": 3
-      },
-      {
-        "language": "makefile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 60,
-        "acceptances_count": 20,
-        "lines_suggested": 152,
-        "lines_accepted": 47,
-        "active_users": 4
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 134,
-        "acceptances_count": 58,
-        "lines_suggested": 682,
-        "lines_accepted": 331,
-        "active_users": 3
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 23,
-        "acceptances_count": 19,
-        "lines_suggested": 25,
-        "lines_accepted": 20,
-        "active_users": 2
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 14,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 10,
-        "lines_suggested": 80,
-        "lines_accepted": 10,
-        "active_users": 7
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 43,
-        "acceptances_count": 3,
-        "lines_suggested": 88,
-        "lines_accepted": 5,
-        "active_users": 3
-      },
-      {
-        "language": "toml",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 208,
-        "acceptances_count": 20,
-        "lines_suggested": 294,
-        "lines_accepted": 27,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 407,
-        "acceptances_count": 107,
-        "lines_suggested": 1013,
-        "lines_accepted": 272,
-        "active_users": 14
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 53,
-        "acceptances_count": 6,
-        "lines_suggested": 80,
-        "lines_accepted": 6,
-        "active_users": 4
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 2,
-        "lines_suggested": 18,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 6,
-        "lines_suggested": 19,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 86,
-        "acceptances_count": 8,
-        "lines_suggested": 98,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 39,
-        "acceptances_count": 12,
-        "lines_suggested": 48,
-        "lines_accepted": 14,
-        "active_users": 2
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 34,
-        "acceptances_count": 8,
-        "lines_suggested": 89,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "properties",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 63,
-        "acceptances_count": 15,
-        "lines_suggested": 89,
-        "lines_accepted": 23,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 18,
-        "acceptances_count": 3,
-        "lines_suggested": 23,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 14,
-        "acceptances_count": 11,
-        "lines_suggested": 38,
-        "lines_accepted": 33,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 9,
-        "acceptances_count": 2,
-        "lines_suggested": 15,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 16,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "jetbrains",
-        "suggestions_count": 10,
-        "acceptances_count": 1,
-        "lines_suggested": 29,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 32,
-        "acceptances_count": 4,
-        "lines_suggested": 45,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 3,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 343,
-        "acceptances_count": 71,
-        "lines_suggested": 1603,
-        "lines_accepted": 113,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 18,
-        "acceptances_count": 3,
-        "lines_suggested": 48,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "emacs-lisp",
-        "editor": "emacs",
-        "suggestions_count": 10,
-        "acceptances_count": 2,
-        "lines_suggested": 13,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "rjsx",
-        "editor": "emacs",
-        "suggestions_count": 30,
-        "acceptances_count": 9,
-        "lines_suggested": 107,
-        "lines_accepted": 62,
-        "active_users": 2
-      },
-      {
-        "language": "graphql",
-        "editor": "emacs",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 28,
-        "lines_accepted": 0,
-        "active_users": 1
-      }
-    ]
-  },
-  {
-    "day": "2024-04-09",
-    "total_suggestions_count": 10008,
-    "total_acceptances_count": 2391,
-    "total_lines_suggested": 18542,
-    "total_lines_accepted": 4514,
-    "total_active_users": 112,
-    "breakdown": [
-      {
-        "language": "gemfile",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 21,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 510,
-        "acceptances_count": 182,
-        "lines_suggested": 1214,
-        "lines_accepted": 457,
-        "active_users": 9
-      },
-      {
-        "language": "html.erb",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 6,
-        "lines_suggested": 44,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "objective-cpp",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 16,
-        "acceptances_count": 1,
-        "lines_suggested": 18,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "properties",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 10,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "restructuredtext",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 28,
-        "acceptances_count": 4,
-        "lines_suggested": 108,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 601,
-        "acceptances_count": 103,
-        "lines_suggested": 900,
-        "lines_accepted": 126,
-        "active_users": 11
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 511,
-        "acceptances_count": 189,
-        "lines_suggested": 809,
-        "lines_accepted": 316,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 471,
-        "acceptances_count": 156,
-        "lines_suggested": 1025,
-        "lines_accepted": 310,
-        "active_users": 22
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 561,
-        "acceptances_count": 174,
-        "lines_suggested": 787,
-        "lines_accepted": 188,
-        "active_users": 11
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 559,
-        "acceptances_count": 189,
-        "lines_suggested": 1005,
-        "lines_accepted": 435,
-        "active_users": 19
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 93,
-        "acceptances_count": 53,
-        "lines_suggested": 912,
-        "lines_accepted": 352,
-        "active_users": 9
-      },
-      {
-        "language": "groovy",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 51,
-        "acceptances_count": 8,
-        "lines_suggested": 73,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 302,
-        "acceptances_count": 68,
-        "lines_suggested": 522,
-        "lines_accepted": 84,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 26,
-        "lines_suggested": 211,
-        "lines_accepted": 180,
-        "active_users": 3
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 2,
-        "lines_suggested": 5,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1267,
-        "acceptances_count": 375,
-        "lines_suggested": 2019,
-        "lines_accepted": 620,
-        "active_users": 15
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 39,
-        "acceptances_count": 9,
-        "lines_suggested": 62,
-        "lines_accepted": 15,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2577,
-        "acceptances_count": 375,
-        "lines_suggested": 3681,
-        "lines_accepted": 417,
-        "active_users": 17
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 17,
-        "acceptances_count": 1,
-        "lines_suggested": 24,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 74,
-        "acceptances_count": 38,
-        "lines_suggested": 81,
-        "lines_accepted": 42,
-        "active_users": 4
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 9,
-        "acceptances_count": 1,
-        "lines_suggested": 15,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 136,
-        "acceptances_count": 24,
-        "lines_suggested": 414,
-        "lines_accepted": 148,
-        "active_users": 11
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 438,
-        "acceptances_count": 16,
-        "lines_suggested": 600,
-        "lines_accepted": 22,
-        "active_users": 3
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 395,
-        "acceptances_count": 79,
-        "lines_suggested": 631,
-        "lines_accepted": 143,
-        "active_users": 13
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 41,
-        "acceptances_count": 19,
-        "lines_suggested": 51,
-        "lines_accepted": 19,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "bicep",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "astro",
-        "editor": "vscode",
-        "suggestions_count": 57,
-        "acceptances_count": 20,
-        "lines_suggested": 312,
-        "lines_accepted": 99,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 33,
-        "acceptances_count": 3,
-        "lines_suggested": 37,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 26,
-        "acceptances_count": 7,
-        "lines_suggested": 61,
-        "lines_accepted": 11,
-        "active_users": 2
-      },
-      {
-        "language": "vs-markdown",
-        "editor": "visual_studio",
-        "suggestions_count": 7,
-        "acceptances_count": 0,
-        "lines_suggested": 7,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 42,
-        "acceptances_count": 20,
-        "lines_suggested": 94,
-        "lines_accepted": 66,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "visual_studio",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "visual_studio",
-        "suggestions_count": 18,
-        "acceptances_count": 13,
-        "lines_suggested": 18,
-        "lines_accepted": 13,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "visual_studio",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 80,
-        "acceptances_count": 5,
-        "lines_suggested": 194,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 69,
-        "acceptances_count": 10,
-        "lines_suggested": 128,
-        "lines_accepted": 13,
-        "active_users": 3
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 44,
-        "acceptances_count": 18,
-        "lines_suggested": 55,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 124,
-        "acceptances_count": 41,
-        "lines_suggested": 285,
-        "lines_accepted": 75,
-        "active_users": 4
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 25,
-        "acceptances_count": 10,
-        "lines_suggested": 105,
-        "lines_accepted": 20,
-        "active_users": 2
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 16,
-        "acceptances_count": 3,
-        "lines_suggested": 40,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 36,
-        "acceptances_count": 9,
-        "lines_suggested": 53,
-        "lines_accepted": 13,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sshconfig",
-        "editor": "vim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 20,
-        "acceptances_count": 3,
-        "lines_suggested": 134,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "eruby",
-        "editor": "neovim",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 4,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "neovim",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "neovim",
-        "suggestions_count": 383,
-        "acceptances_count": 79,
-        "lines_suggested": 1185,
-        "lines_accepted": 151,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "neovim",
-        "suggestions_count": 3,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 6,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 53,
-        "acceptances_count": 6,
-        "lines_suggested": 190,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "neovim",
-        "suggestions_count": 43,
-        "acceptances_count": 10,
-        "lines_suggested": 108,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "neovim",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 48,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "emacs-lisp",
-        "editor": "emacs",
-        "suggestions_count": 79,
-        "acceptances_count": 29,
-        "lines_suggested": 171,
-        "lines_accepted": 85,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-10",
-    "total_suggestions_count": 10301,
-    "total_acceptances_count": 2600,
-    "total_lines_suggested": 18825,
-    "total_lines_accepted": 4752,
-    "total_active_users": 125,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 15,
-        "acceptances_count": 0,
-        "lines_suggested": 20,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 377,
-        "acceptances_count": 139,
-        "lines_suggested": 537,
-        "lines_accepted": 189,
-        "active_users": 4
-      },
-      {
-        "language": "html.erb",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 2,
-        "lines_suggested": 30,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "vscode",
-        "suggestions_count": 54,
-        "acceptances_count": 39,
-        "lines_suggested": 156,
-        "lines_accepted": 60,
-        "active_users": 2
-      },
-      {
-        "language": "kusto",
-        "editor": "vscode",
-        "suggestions_count": 21,
-        "acceptances_count": 2,
-        "lines_suggested": 29,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "nunjucks",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 0,
-        "lines_suggested": 21,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "terraform-vars",
-        "editor": "vscode",
-        "suggestions_count": 37,
-        "acceptances_count": 23,
-        "lines_suggested": 41,
-        "lines_accepted": 23,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 573,
-        "acceptances_count": 164,
-        "lines_suggested": 833,
-        "lines_accepted": 230,
-        "active_users": 9
-      },
-      {
-        "language": "unknown",
-        "editor": "vscode",
-        "suggestions_count": 161,
-        "acceptances_count": 66,
-        "lines_suggested": 302,
-        "lines_accepted": 66,
-        "active_users": 5
-      },
-      {
-        "language": "vb",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 1,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 324,
-        "acceptances_count": 96,
-        "lines_suggested": 486,
-        "lines_accepted": 139,
-        "active_users": 8
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 1388,
-        "acceptances_count": 349,
-        "lines_suggested": 2723,
-        "lines_accepted": 978,
-        "active_users": 24
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 737,
-        "acceptances_count": 259,
-        "lines_suggested": 2016,
-        "lines_accepted": 426,
-        "active_users": 16
-      },
-      {
-        "language": "c++",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 1546,
-        "acceptances_count": 430,
-        "lines_suggested": 2786,
-        "lines_accepted": 830,
-        "active_users": 22
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 223,
-        "acceptances_count": 119,
-        "lines_suggested": 670,
-        "lines_accepted": 347,
-        "active_users": 14
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 181,
-        "acceptances_count": 48,
-        "lines_suggested": 236,
-        "lines_accepted": 57,
-        "active_users": 8
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 46,
-        "acceptances_count": 26,
-        "lines_suggested": 146,
-        "lines_accepted": 103,
-        "active_users": 4
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 34,
-        "acceptances_count": 7,
-        "lines_suggested": 106,
-        "lines_accepted": 28,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 5,
-        "lines_suggested": 25,
-        "lines_accepted": 13,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1472,
-        "acceptances_count": 316,
-        "lines_suggested": 2438,
-        "lines_accepted": 559,
-        "active_users": 12
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 99,
-        "acceptances_count": 19,
-        "lines_suggested": 229,
-        "lines_accepted": 47,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1643,
-        "acceptances_count": 208,
-        "lines_suggested": 2231,
-        "lines_accepted": 236,
-        "active_users": 24
-      },
-      {
-        "language": "tex",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 19,
-        "acceptances_count": 10,
-        "lines_suggested": 58,
-        "lines_accepted": 25,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 112,
-        "acceptances_count": 25,
-        "lines_suggested": 245,
-        "lines_accepted": 49,
-        "active_users": 10
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 85,
-        "acceptances_count": 14,
-        "lines_suggested": 120,
-        "lines_accepted": 26,
-        "active_users": 3
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html+erb",
-        "editor": "vscode",
-        "suggestions_count": 32,
-        "acceptances_count": 2,
-        "lines_suggested": 55,
-        "lines_accepted": 2,
-        "active_users": 3
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 79,
-        "acceptances_count": 8,
-        "lines_suggested": 88,
-        "lines_accepted": 11,
-        "active_users": 7
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 40,
-        "acceptances_count": 1,
-        "lines_suggested": 140,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 69,
-        "acceptances_count": 5,
-        "lines_suggested": 154,
-        "lines_accepted": 5,
-        "active_users": 5
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 293,
-        "acceptances_count": 82,
-        "lines_suggested": 396,
-        "lines_accepted": 108,
-        "active_users": 13
-      },
-      {
-        "language": "postcss",
-        "editor": "vscode",
-        "suggestions_count": 76,
-        "acceptances_count": 23,
-        "lines_suggested": 209,
-        "lines_accepted": 31,
-        "active_users": 2
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 72,
-        "acceptances_count": 4,
-        "lines_suggested": 100,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 22,
-        "acceptances_count": 3,
-        "lines_suggested": 33,
-        "lines_accepted": 3,
-        "active_users": 3
-      },
-      {
-        "language": "prisma",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "mdx",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 31,
-        "acceptances_count": 2,
-        "lines_suggested": 59,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "javascriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 7,
-        "acceptances_count": 3,
-        "lines_suggested": 35,
-        "lines_accepted": 13,
-        "active_users": 2
-      },
-      {
-        "language": "razor",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 4,
-        "lines_suggested": 30,
-        "lines_accepted": 14,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 13,
-        "acceptances_count": 0,
-        "lines_suggested": 37,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "kotlin",
-        "editor": "jetbrains",
-        "suggestions_count": 52,
-        "acceptances_count": 13,
-        "lines_suggested": 87,
-        "lines_accepted": 18,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "markdown",
-        "editor": "jetbrains",
-        "suggestions_count": 11,
-        "acceptances_count": 0,
-        "lines_suggested": 14,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "vim",
-        "suggestions_count": 7,
-        "acceptances_count": 1,
-        "lines_suggested": 8,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "neovim",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 13,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascript",
-        "editor": "neovim",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 21,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 177,
-        "acceptances_count": 56,
-        "lines_suggested": 458,
-        "lines_accepted": 66,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 102,
-        "acceptances_count": 19,
-        "lines_suggested": 348,
-        "lines_accepted": 19,
-        "active_users": 2
-      },
-      {
-        "language": "emacs-lisp",
-        "editor": "emacs",
-        "suggestions_count": 10,
-        "acceptances_count": 5,
-        "lines_suggested": 34,
-        "lines_accepted": 16,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-11",
-    "total_suggestions_count": 11811,
-    "total_acceptances_count": 3194,
-    "total_lines_suggested": 20636,
-    "total_lines_accepted": 5512,
-    "total_active_users": 116,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 48,
-        "acceptances_count": 2,
-        "lines_suggested": 61,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "github-actions-workflow",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 2,
-        "lines_suggested": 10,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "pip-requirements",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 54,
-        "acceptances_count": 8,
-        "lines_suggested": 92,
-        "lines_accepted": 9,
-        "active_users": 3
-      },
-      {
-        "language": "scminput",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 889,
-        "acceptances_count": 240,
-        "lines_suggested": 1325,
-        "lines_accepted": 326,
-        "active_users": 16
-      },
-      {
-        "language": "unknown",
-        "editor": "vscode",
-        "suggestions_count": 397,
-        "acceptances_count": 113,
-        "lines_suggested": 923,
-        "lines_accepted": 174,
-        "active_users": 15
-      },
-      {
-        "language": "vb",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 2,
-        "lines_suggested": 7,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 255,
-        "acceptances_count": 95,
-        "lines_suggested": 349,
-        "lines_accepted": 100,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 1386,
-        "acceptances_count": 421,
-        "lines_suggested": 2418,
-        "lines_accepted": 817,
-        "active_users": 23
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 449,
-        "acceptances_count": 128,
-        "lines_suggested": 647,
-        "lines_accepted": 159,
-        "active_users": 10
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 740,
-        "acceptances_count": 313,
-        "lines_suggested": 1111,
-        "lines_accepted": 507,
-        "active_users": 16
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 245,
-        "acceptances_count": 115,
-        "lines_suggested": 1091,
-        "lines_accepted": 460,
-        "active_users": 10
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 1,
-        "lines_suggested": 7,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 584,
-        "acceptances_count": 172,
-        "lines_suggested": 1087,
-        "lines_accepted": 236,
-        "active_users": 6
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 39,
-        "lines_suggested": 269,
-        "lines_accepted": 200,
-        "active_users": 5
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 128,
-        "acceptances_count": 32,
-        "lines_suggested": 218,
-        "lines_accepted": 57,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 6,
-        "lines_suggested": 21,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "dart",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 8,
-        "acceptances_count": 0,
-        "lines_suggested": 9,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 2130,
-        "acceptances_count": 432,
-        "lines_suggested": 3175,
-        "lines_accepted": 734,
-        "active_users": 16
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 197,
-        "acceptances_count": 36,
-        "lines_suggested": 396,
-        "lines_accepted": 66,
-        "active_users": 8
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2040,
-        "acceptances_count": 337,
-        "lines_suggested": 2930,
-        "lines_accepted": 392,
-        "active_users": 16
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 57,
-        "acceptances_count": 36,
-        "lines_suggested": 98,
-        "lines_accepted": 73,
-        "active_users": 4
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 48,
-        "acceptances_count": 11,
-        "lines_suggested": 176,
-        "lines_accepted": 54,
-        "active_users": 6
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 87,
-        "acceptances_count": 18,
-        "lines_suggested": 251,
-        "lines_accepted": 58,
-        "active_users": 5
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 15,
-        "acceptances_count": 3,
-        "lines_suggested": 18,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 113,
-        "acceptances_count": 19,
-        "lines_suggested": 172,
-        "lines_accepted": 44,
-        "active_users": 9
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 225,
-        "acceptances_count": 19,
-        "lines_suggested": 242,
-        "lines_accepted": 19,
-        "active_users": 4
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 876,
-        "acceptances_count": 370,
-        "lines_suggested": 1688,
-        "lines_accepted": 566,
-        "active_users": 20
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 44,
-        "acceptances_count": 2,
-        "lines_suggested": 66,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "ignore list",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "c#",
-        "editor": "visual_studio",
-        "suggestions_count": 136,
-        "acceptances_count": 62,
-        "lines_suggested": 418,
-        "lines_accepted": 193,
-        "active_users": 3
-      },
-      {
-        "language": "blazor",
-        "editor": "jetbrains",
-        "suggestions_count": 19,
-        "acceptances_count": 2,
-        "lines_suggested": 105,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 125,
-        "acceptances_count": 52,
-        "lines_suggested": 260,
-        "lines_accepted": 88,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 1,
-        "lines_suggested": 4,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 42,
-        "acceptances_count": 10,
-        "lines_suggested": 49,
-        "lines_accepted": 12,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 7,
-        "acceptances_count": 3,
-        "lines_suggested": 7,
-        "lines_accepted": 3,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 81,
-        "acceptances_count": 18,
-        "lines_suggested": 247,
-        "lines_accepted": 26,
-        "active_users": 3
-      },
-      {
-        "language": "xml",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "jetbrains",
-        "suggestions_count": 9,
-        "acceptances_count": 7,
-        "lines_suggested": 9,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "html",
-        "editor": "jetbrains",
-        "suggestions_count": 1,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "neovim",
-        "suggestions_count": 89,
-        "acceptances_count": 26,
-        "lines_suggested": 196,
-        "lines_accepted": 36,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "neovim",
-        "suggestions_count": 30,
-        "acceptances_count": 5,
-        "lines_suggested": 70,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "ruby",
-        "editor": "neovim",
-        "suggestions_count": 22,
-        "acceptances_count": 2,
-        "lines_suggested": 68,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "neovim",
-        "suggestions_count": 8,
-        "acceptances_count": 5,
-        "lines_suggested": 11,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "markdown",
-        "editor": "neovim",
-        "suggestions_count": 30,
-        "acceptances_count": 1,
-        "lines_suggested": 115,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "toml",
-        "editor": "neovim",
-        "suggestions_count": 24,
-        "acceptances_count": 3,
-        "lines_suggested": 89,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "emacs-lisp",
-        "editor": "emacs",
-        "suggestions_count": 62,
-        "acceptances_count": 24,
-        "lines_suggested": 113,
-        "lines_accepted": 48,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-12",
-    "total_suggestions_count": 9105,
-    "total_acceptances_count": 2137,
-    "total_lines_suggested": 14478,
-    "total_lines_accepted": 3554,
-    "total_active_users": 105,
-    "breakdown": [
-      {
-        "language": "git-commit",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "ql",
-        "editor": "vscode",
-        "suggestions_count": 62,
-        "acceptances_count": 13,
-        "lines_suggested": 95,
-        "lines_accepted": 16,
-        "active_users": 3
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 606,
-        "acceptances_count": 95,
-        "lines_suggested": 942,
-        "lines_accepted": 163,
-        "active_users": 9
-      },
-      {
-        "language": "unknown",
-        "editor": "vscode",
-        "suggestions_count": 474,
-        "acceptances_count": 14,
-        "lines_suggested": 534,
-        "lines_accepted": 14,
-        "active_users": 7
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 61,
-        "acceptances_count": 25,
-        "lines_suggested": 85,
-        "lines_accepted": 28,
-        "active_users": 6
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 619,
-        "acceptances_count": 235,
-        "lines_suggested": 1295,
-        "lines_accepted": 540,
-        "active_users": 19
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 418,
-        "acceptances_count": 87,
-        "lines_suggested": 566,
-        "lines_accepted": 97,
-        "active_users": 13
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 702,
-        "acceptances_count": 225,
-        "lines_suggested": 942,
-        "lines_accepted": 299,
-        "active_users": 16
-      },
-      {
-        "language": "php",
-        "editor": "vscode",
-        "suggestions_count": 18,
-        "acceptances_count": 0,
-        "lines_suggested": 38,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "objective-c",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 3,
-        "lines_suggested": 31,
-        "lines_accepted": 15,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 50,
-        "acceptances_count": 24,
-        "lines_suggested": 100,
-        "lines_accepted": 45,
-        "active_users": 5
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 757,
-        "acceptances_count": 274,
-        "lines_suggested": 1608,
-        "lines_accepted": 512,
-        "active_users": 4
-      },
-      {
-        "language": "c#",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 2,
-        "lines_suggested": 7,
-        "lines_accepted": 4,
-        "active_users": 2
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 82,
-        "acceptances_count": 10,
-        "lines_suggested": 112,
-        "lines_accepted": 10,
-        "active_users": 2
-      },
-      {
-        "language": "powershell",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "kotlin",
-        "editor": "vscode",
-        "suggestions_count": 11,
-        "acceptances_count": 8,
-        "lines_suggested": 94,
-        "lines_accepted": 25,
-        "active_users": 2
-      },
-      {
-        "language": "xml",
-        "editor": "vscode",
-        "suggestions_count": 10,
-        "acceptances_count": 1,
-        "lines_suggested": 56,
-        "lines_accepted": 16,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 1341,
-        "acceptances_count": 378,
-        "lines_suggested": 1923,
-        "lines_accepted": 594,
-        "active_users": 12
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 107,
-        "acceptances_count": 30,
-        "lines_suggested": 156,
-        "lines_accepted": 37,
-        "active_users": 4
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 2182,
-        "acceptances_count": 391,
-        "lines_suggested": 3096,
-        "lines_accepted": 450,
-        "active_users": 26
-      },
-      {
-        "language": "tex",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 45,
-        "acceptances_count": 21,
-        "lines_suggested": 62,
-        "lines_accepted": 37,
-        "active_users": 3
-      },
-      {
-        "language": "makefile",
-        "editor": "vscode",
-        "suggestions_count": 5,
-        "acceptances_count": 0,
-        "lines_suggested": 5,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "html",
-        "editor": "vscode",
-        "suggestions_count": 72,
-        "acceptances_count": 21,
-        "lines_suggested": 165,
-        "lines_accepted": 31,
-        "active_users": 7
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 5,
-        "lines_suggested": 36,
-        "lines_accepted": 5,
-        "active_users": 3
-      },
-      {
-        "language": "ini",
-        "editor": "vscode",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 4,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 71,
-        "acceptances_count": 6,
-        "lines_suggested": 109,
-        "lines_accepted": 6,
-        "active_users": 3
-      },
-      {
-        "language": "scss",
-        "editor": "vscode",
-        "suggestions_count": 2,
-        "acceptances_count": 0,
-        "lines_suggested": 2,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 504,
-        "acceptances_count": 32,
-        "lines_suggested": 642,
-        "lines_accepted": 43,
-        "active_users": 4
-      },
-      {
-        "language": "yaml",
-        "editor": "vscode",
-        "suggestions_count": 403,
-        "acceptances_count": 128,
-        "lines_suggested": 1002,
-        "lines_accepted": 327,
-        "active_users": 15
-      },
-      {
-        "language": "json with comments",
-        "editor": "vscode",
-        "suggestions_count": 31,
-        "acceptances_count": 1,
-        "lines_suggested": 46,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "dotenv",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "vs-markdown",
-        "editor": "visual_studio",
-        "suggestions_count": 31,
-        "acceptances_count": 2,
-        "lines_suggested": 31,
-        "lines_accepted": 2,
-        "active_users": 2
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "jetbrains",
-        "suggestions_count": 247,
-        "acceptances_count": 59,
-        "lines_suggested": 409,
-        "lines_accepted": 117,
-        "active_users": 3
-      },
-      {
-        "language": "shell",
-        "editor": "jetbrains",
-        "suggestions_count": 4,
-        "acceptances_count": 0,
-        "lines_suggested": 6,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascript",
-        "editor": "jetbrains",
-        "suggestions_count": 5,
-        "acceptances_count": 1,
-        "lines_suggested": 5,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "python",
-        "editor": "jetbrains",
-        "suggestions_count": 2,
-        "acceptances_count": 1,
-        "lines_suggested": 2,
-        "lines_accepted": 1,
-        "active_users": 2
-      },
-      {
-        "language": "java",
-        "editor": "jetbrains",
-        "suggestions_count": 32,
-        "acceptances_count": 18,
-        "lines_suggested": 90,
-        "lines_accepted": 66,
-        "active_users": 3
-      },
-      {
-        "language": "c#",
-        "editor": "jetbrains",
-        "suggestions_count": 45,
-        "acceptances_count": 9,
-        "lines_suggested": 109,
-        "lines_accepted": 33,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "jetbrains",
-        "suggestions_count": 33,
-        "acceptances_count": 6,
-        "lines_suggested": 37,
-        "lines_accepted": 6,
-        "active_users": 2
-      },
-      {
-        "language": "yaml",
-        "editor": "jetbrains",
-        "suggestions_count": 3,
-        "acceptances_count": 2,
-        "lines_suggested": 4,
-        "lines_accepted": 3,
-        "active_users": 2
-      },
-      {
-        "language": "javascript",
-        "editor": "neovim",
-        "suggestions_count": 15,
-        "acceptances_count": 8,
-        "lines_suggested": 16,
-        "lines_accepted": 8,
-        "active_users": 2
-      },
-      {
-        "language": "emacs-lisp",
-        "editor": "emacs",
-        "suggestions_count": 3,
-        "acceptances_count": 2,
-        "lines_suggested": 3,
-        "lines_accepted": 2,
-        "active_users": 2
-      }
-    ]
-  },
-  {
-    "day": "2024-04-13",
-    "total_suggestions_count": 2470,
-    "total_acceptances_count": 672,
-    "total_lines_suggested": 3756,
-    "total_lines_accepted": 880,
-    "total_active_users": 25,
-    "breakdown": [
-      {
-        "language": "postgres",
-        "editor": "vscode",
-        "suggestions_count": 6,
-        "acceptances_count": 0,
-        "lines_suggested": 12,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "typescriptreact",
-        "editor": "vscode",
-        "suggestions_count": 120,
-        "acceptances_count": 16,
-        "lines_suggested": 173,
-        "lines_accepted": 27,
-        "active_users": 6
-      },
-      {
-        "language": "unknown",
-        "editor": "vscode",
-        "suggestions_count": 75,
-        "acceptances_count": 24,
-        "lines_suggested": 111,
-        "lines_accepted": 35,
-        "active_users": 2
-      },
-      {
-        "language": "shell",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "javascript",
-        "editor": "vscode",
-        "suggestions_count": 56,
-        "acceptances_count": 14,
-        "lines_suggested": 104,
-        "lines_accepted": 34,
-        "active_users": 5
-      },
-      {
-        "language": "ruby",
-        "editor": "vscode",
-        "suggestions_count": 12,
-        "acceptances_count": 4,
-        "lines_suggested": 12,
-        "lines_accepted": 4,
-        "active_users": 3
-      },
-      {
-        "language": "python",
-        "editor": "vscode",
-        "suggestions_count": 124,
-        "acceptances_count": 48,
-        "lines_suggested": 168,
-        "lines_accepted": 74,
-        "active_users": 3
-      },
-      {
-        "language": "java",
-        "editor": "vscode",
-        "suggestions_count": 29,
-        "acceptances_count": 15,
-        "lines_suggested": 98,
-        "lines_accepted": 42,
-        "active_users": 3
-      },
-      {
-        "language": "r",
-        "editor": "vscode",
-        "suggestions_count": 67,
-        "acceptances_count": 5,
-        "lines_suggested": 89,
-        "lines_accepted": 5,
-        "active_users": 2
-      },
-      {
-        "language": "go",
-        "editor": "vscode",
-        "suggestions_count": 266,
-        "acceptances_count": 111,
-        "lines_suggested": 480,
-        "lines_accepted": 171,
-        "active_users": 3
-      },
-      {
-        "language": "rust",
-        "editor": "vscode",
-        "suggestions_count": 7,
-        "acceptances_count": 2,
-        "lines_suggested": 26,
-        "lines_accepted": 7,
-        "active_users": 2
-      },
-      {
-        "language": "typescript",
-        "editor": "vscode",
-        "suggestions_count": 215,
-        "acceptances_count": 43,
-        "lines_suggested": 259,
-        "lines_accepted": 48,
-        "active_users": 5
-      },
-      {
-        "language": "css",
-        "editor": "vscode",
-        "suggestions_count": 68,
-        "acceptances_count": 15,
-        "lines_suggested": 104,
-        "lines_accepted": 25,
-        "active_users": 3
-      },
-      {
-        "language": "markdown",
-        "editor": "vscode",
-        "suggestions_count": 1146,
-        "acceptances_count": 313,
-        "lines_suggested": 1571,
-        "lines_accepted": 321,
-        "active_users": 6
-      },
-      {
-        "language": "sql",
-        "editor": "vscode",
-        "suggestions_count": 45,
-        "acceptances_count": 17,
-        "lines_suggested": 76,
-        "lines_accepted": 33,
-        "active_users": 3
-      },
-      {
-        "language": "makefile",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "hcl",
-        "editor": "vscode",
-        "suggestions_count": 1,
-        "acceptances_count": 0,
-        "lines_suggested": 1,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "dockerfile",
-        "editor": "vscode",
-        "suggestions_count": 3,
-        "acceptances_count": 0,
-        "lines_suggested": 3,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "json",
-        "editor": "vscode",
-        "suggestions_count": 31,
-        "acceptances_count": 0,
-        "lines_suggested": 49,
-        "lines_accepted": 0,
-        "active_users": 1
-      },
-      {
-        "language": "text",
-        "editor": "vscode",
-        "suggestions_count": 102,
-        "acceptances_count": 18,
-        "lines_suggested": 282,
-        "lines_accepted": 25,
-        "active_users": 2
-      },
-      {
-        "language": "fsharp",
-        "editor": "visual_studio",
-        "suggestions_count": 93,
-        "acceptances_count": 27,
-        "lines_suggested": 134,
-        "lines_accepted": 29,
-        "active_users": 2
-      }
-    ]
-  }
+    {
+        "day": "2024-03-18",
+        "total_suggestions_count": 8312,
+        "total_acceptances_count": 2009,
+        "total_lines_suggested": 35290,
+        "total_lines_accepted": 5038,
+        "total_active_users": 97,
+        "total_chat_acceptances": 174,
+        "total_chat_turns": 119,
+        "total_active_chat_users": 38,
+        "breakdown": [
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 2,
+                "lines_suggested": 133,
+                "lines_accepted": 66,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 68,
+                "acceptances_count": 3,
+                "lines_suggested": 90,
+                "lines_accepted": 3,
+                "active_users": 4
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 191,
+                "acceptances_count": 51,
+                "lines_suggested": 355,
+                "lines_accepted": 148,
+                "active_users": 4
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 1,
+                "lines_suggested": 81,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 2,
+                "lines_suggested": 27,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 2,
+                "lines_suggested": 24,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 11,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 34,
+                "acceptances_count": 2,
+                "lines_suggested": 100,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 542,
+                "acceptances_count": 154,
+                "lines_suggested": 1064,
+                "lines_accepted": 419,
+                "active_users": 13
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 162,
+                "acceptances_count": 46,
+                "lines_suggested": 223,
+                "lines_accepted": 61,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 701,
+                "acceptances_count": 213,
+                "lines_suggested": 1813,
+                "lines_accepted": 723,
+                "active_users": 29
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 257,
+                "acceptances_count": 92,
+                "lines_suggested": 316,
+                "lines_accepted": 102,
+                "active_users": 11
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 170,
+                "acceptances_count": 60,
+                "lines_suggested": 377,
+                "lines_accepted": 136,
+                "active_users": 8
+            },
+            {
+                "language": "c",
+                "editor": "vscode",
+                "suggestions_count": 110,
+                "acceptances_count": 20,
+                "lines_suggested": 339,
+                "lines_accepted": 67,
+                "active_users": 3
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 108,
+                "acceptances_count": 55,
+                "lines_suggested": 591,
+                "lines_accepted": 203,
+                "active_users": 8
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 7,
+                "lines_suggested": 16,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 79,
+                "acceptances_count": 26,
+                "lines_suggested": 100,
+                "lines_accepted": 26,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 250,
+                "acceptances_count": 58,
+                "lines_suggested": 561,
+                "lines_accepted": 84,
+                "active_users": 4
+            },
+            {
+                "language": "coffeescript",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 3,
+                "lines_suggested": 3,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 53,
+                "acceptances_count": 19,
+                "lines_suggested": 258,
+                "lines_accepted": 177,
+                "active_users": 6
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 190,
+                "acceptances_count": 109,
+                "lines_suggested": 804,
+                "lines_accepted": 522,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 54,
+                "acceptances_count": 22,
+                "lines_suggested": 103,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 961,
+                "acceptances_count": 209,
+                "lines_suggested": 1663,
+                "lines_accepted": 323,
+                "active_users": 10
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 170,
+                "acceptances_count": 29,
+                "lines_suggested": 391,
+                "lines_accepted": 80,
+                "active_users": 4
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1476,
+                "acceptances_count": 215,
+                "lines_suggested": 1987,
+                "lines_accepted": 280,
+                "active_users": 11
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 12,
+                "lines_suggested": 38,
+                "lines_accepted": 28,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 33,
+                "acceptances_count": 5,
+                "lines_suggested": 45,
+                "lines_accepted": 5,
+                "active_users": 3
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 8,
+                "lines_suggested": 60,
+                "lines_accepted": 53,
+                "active_users": 4
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 53,
+                "acceptances_count": 5,
+                "lines_suggested": 106,
+                "lines_accepted": 8,
+                "active_users": 5
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 72,
+                "acceptances_count": 16,
+                "lines_suggested": 286,
+                "lines_accepted": 199,
+                "active_users": 7
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 52,
+                "acceptances_count": 19,
+                "lines_suggested": 9746,
+                "lines_accepted": 20,
+                "active_users": 4
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 440,
+                "acceptances_count": 95,
+                "lines_suggested": 670,
+                "lines_accepted": 161,
+                "active_users": 8
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 2,
+                "lines_suggested": 6,
+                "lines_accepted": 3,
+                "active_users": 3
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 2,
+                "lines_suggested": 39,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 211,
+                "acceptances_count": 28,
+                "lines_suggested": 582,
+                "lines_accepted": 28,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 14,
+                "acceptances_count": 4,
+                "lines_suggested": 27,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "properties",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 16,
+                "acceptances_count": 5,
+                "lines_suggested": 44,
+                "lines_accepted": 15,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 85,
+                "acceptances_count": 32,
+                "lines_suggested": 287,
+                "lines_accepted": 89,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 25,
+                "acceptances_count": 10,
+                "lines_suggested": 79,
+                "lines_accepted": 45,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1535,
+                "acceptances_count": 360,
+                "lines_suggested": 11734,
+                "lines_accepted": 891,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 49,
+                "lines_accepted": 2,
+                "active_users": 2
+            }
+        ]
+    },
+    {
+        "day": "2024-03-19",
+        "total_suggestions_count": 10148,
+        "total_acceptances_count": 2443,
+        "total_lines_suggested": 24150,
+        "total_lines_accepted": 5268,
+        "total_active_users": 121,
+        "breakdown": [
+            {
+                "language": "bat",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 11,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 34,
+                "acceptances_count": 0,
+                "lines_suggested": 36,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 123,
+                "acceptances_count": 62,
+                "lines_suggested": 180,
+                "lines_accepted": 76,
+                "active_users": 9
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java-properties",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json5",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 17,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 1,
+                "lines_suggested": 46,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 38,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 2,
+                "lines_suggested": 22,
+                "lines_accepted": 3,
+                "active_users": 3
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 115,
+                "acceptances_count": 14,
+                "lines_suggested": 254,
+                "lines_accepted": 19,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1162,
+                "acceptances_count": 346,
+                "lines_suggested": 2044,
+                "lines_accepted": 680,
+                "active_users": 17
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 263,
+                "acceptances_count": 94,
+                "lines_suggested": 373,
+                "lines_accepted": 134,
+                "active_users": 12
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 915,
+                "acceptances_count": 288,
+                "lines_suggested": 2670,
+                "lines_accepted": 955,
+                "active_users": 27
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 316,
+                "acceptances_count": 90,
+                "lines_suggested": 381,
+                "lines_accepted": 101,
+                "active_users": 7
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 124,
+                "acceptances_count": 65,
+                "lines_suggested": 440,
+                "lines_accepted": 190,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 464,
+                "acceptances_count": 125,
+                "lines_suggested": 1184,
+                "lines_accepted": 301,
+                "active_users": 13
+            },
+            {
+                "language": "c",
+                "editor": "vscode",
+                "suggestions_count": 36,
+                "acceptances_count": 9,
+                "lines_suggested": 57,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 155,
+                "acceptances_count": 79,
+                "lines_suggested": 795,
+                "lines_accepted": 532,
+                "active_users": 12
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 557,
+                "acceptances_count": 156,
+                "lines_suggested": 950,
+                "lines_accepted": 253,
+                "active_users": 7
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 80,
+                "acceptances_count": 19,
+                "lines_suggested": 280,
+                "lines_accepted": 48,
+                "active_users": 4
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 28,
+                "acceptances_count": 12,
+                "lines_suggested": 95,
+                "lines_accepted": 44,
+                "active_users": 4
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 13,
+                "lines_suggested": 89,
+                "lines_accepted": 20,
+                "active_users": 4
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1074,
+                "acceptances_count": 268,
+                "lines_suggested": 1746,
+                "lines_accepted": 468,
+                "active_users": 14
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 201,
+                "acceptances_count": 23,
+                "lines_suggested": 417,
+                "lines_accepted": 56,
+                "active_users": 4
+            },
+            {
+                "language": "cobol",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2310,
+                "acceptances_count": 346,
+                "lines_suggested": 3307,
+                "lines_accepted": 381,
+                "active_users": 19
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 106,
+                "acceptances_count": 30,
+                "lines_suggested": 174,
+                "lines_accepted": 41,
+                "active_users": 5
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 36,
+                "acceptances_count": 14,
+                "lines_suggested": 116,
+                "lines_accepted": 81,
+                "active_users": 5
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 18,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "graphql",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 2,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 8,
+                "lines_suggested": 28,
+                "lines_accepted": 12,
+                "active_users": 4
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 35,
+                "acceptances_count": 1,
+                "lines_suggested": 43,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 65,
+                "acceptances_count": 10,
+                "lines_suggested": 193,
+                "lines_accepted": 102,
+                "active_users": 7
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 14,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 203,
+                "acceptances_count": 6,
+                "lines_suggested": 283,
+                "lines_accepted": 6,
+                "active_users": 5
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 227,
+                "acceptances_count": 54,
+                "lines_suggested": 342,
+                "lines_accepted": 102,
+                "active_users": 7
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 3,
+                "lines_suggested": 59,
+                "lines_accepted": 3,
+                "active_users": 4
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 50,
+                "acceptances_count": 6,
+                "lines_suggested": 71,
+                "lines_accepted": 7,
+                "active_users": 4
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 87,
+                "acceptances_count": 7,
+                "lines_suggested": 188,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "vs-markdown",
+                "editor": "visual_studio",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 25,
+                "acceptances_count": 9,
+                "lines_suggested": 36,
+                "lines_accepted": 15,
+                "active_users": 3
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 25,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 6,
+                "lines_suggested": 76,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 29,
+                "acceptances_count": 7,
+                "lines_suggested": 112,
+                "lines_accepted": 23,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1075,
+                "acceptances_count": 260,
+                "lines_suggested": 6879,
+                "lines_accepted": 559,
+                "active_users": 2
+            },
+            {
+                "language": "web",
+                "editor": "emacs",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 149,
+        "total_chat_turns": 168,
+        "total_active_chat_users": 7
+    },
+    {
+        "day": "2024-03-20",
+        "total_suggestions_count": 10657,
+        "total_acceptances_count": 2665,
+        "total_lines_suggested": 26459,
+        "total_lines_accepted": 5054,
+        "total_active_users": 113,
+        "breakdown": [
+            {
+                "language": "env",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 2,
+                "lines_suggested": 30,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 406,
+                "acceptances_count": 190,
+                "lines_suggested": 684,
+                "lines_accepted": 231,
+                "active_users": 6
+            },
+            {
+                "language": "java-properties",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 2,
+                "lines_suggested": 41,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "json5",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 0,
+                "lines_suggested": 40,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 18,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 25,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 67,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "terragrunt",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 4,
+                "lines_suggested": 102,
+                "lines_accepted": 24,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 432,
+                "acceptances_count": 131,
+                "lines_suggested": 939,
+                "lines_accepted": 302,
+                "active_users": 14
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 67,
+                "acceptances_count": 22,
+                "lines_suggested": 118,
+                "lines_accepted": 49,
+                "active_users": 5
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 880,
+                "acceptances_count": 256,
+                "lines_suggested": 2257,
+                "lines_accepted": 805,
+                "active_users": 22
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 211,
+                "acceptances_count": 56,
+                "lines_suggested": 323,
+                "lines_accepted": 68,
+                "active_users": 9
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 129,
+                "acceptances_count": 48,
+                "lines_suggested": 585,
+                "lines_accepted": 139,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 648,
+                "acceptances_count": 208,
+                "lines_suggested": 972,
+                "lines_accepted": 344,
+                "active_users": 14
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 246,
+                "acceptances_count": 84,
+                "lines_suggested": 1059,
+                "lines_accepted": 357,
+                "active_users": 8
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 22,
+                "acceptances_count": 2,
+                "lines_suggested": 28,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 2,
+                "lines_suggested": 6,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 41,
+                "acceptances_count": 18,
+                "lines_suggested": 56,
+                "lines_accepted": 20,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 271,
+                "acceptances_count": 106,
+                "lines_suggested": 408,
+                "lines_accepted": 116,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 243,
+                "acceptances_count": 52,
+                "lines_suggested": 1189,
+                "lines_accepted": 131,
+                "active_users": 4
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 140,
+                "acceptances_count": 30,
+                "lines_suggested": 246,
+                "lines_accepted": 51,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 65,
+                "acceptances_count": 24,
+                "lines_suggested": 149,
+                "lines_accepted": 70,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 4,
+                "lines_suggested": 24,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 745,
+                "acceptances_count": 219,
+                "lines_suggested": 1301,
+                "lines_accepted": 332,
+                "active_users": 12
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 135,
+                "acceptances_count": 24,
+                "lines_suggested": 296,
+                "lines_accepted": 56,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2323,
+                "acceptances_count": 415,
+                "lines_suggested": 3830,
+                "lines_accepted": 541,
+                "active_users": 19
+            },
+            {
+                "language": "tex",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 49,
+                "acceptances_count": 10,
+                "lines_suggested": 102,
+                "lines_accepted": 20,
+                "active_users": 3
+            },
+            {
+                "language": "swift",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 4,
+                "lines_suggested": 10,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 2,
+                "lines_suggested": 19,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 16,
+                "lines_suggested": 325,
+                "lines_accepted": 172,
+                "active_users": 6
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 55,
+                "acceptances_count": 0,
+                "lines_suggested": 105,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 341,
+                "acceptances_count": 76,
+                "lines_suggested": 591,
+                "lines_accepted": 118,
+                "active_users": 12
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 16,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 66,
+                "acceptances_count": 14,
+                "lines_suggested": 93,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 4,
+                "lines_suggested": 44,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "svelte",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 7,
+                "lines_suggested": 48,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 87,
+                "acceptances_count": 11,
+                "lines_suggested": 110,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "vs-markdown",
+                "editor": "visual_studio",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 71,
+                "acceptances_count": 26,
+                "lines_suggested": 155,
+                "lines_accepted": 53,
+                "active_users": 2
+            },
+            {
+                "language": "properties",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 15,
+                "acceptances_count": 3,
+                "lines_suggested": 36,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 42,
+                "acceptances_count": 17,
+                "lines_suggested": 70,
+                "lines_accepted": 37,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 194,
+                "acceptances_count": 24,
+                "lines_suggested": 340,
+                "lines_accepted": 34,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 8,
+                "acceptances_count": 4,
+                "lines_suggested": 8,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 105,
+                "acceptances_count": 41,
+                "lines_suggested": 169,
+                "lines_accepted": 44,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 20,
+                "acceptances_count": 7,
+                "lines_suggested": 37,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 14,
+                "acceptances_count": 9,
+                "lines_suggested": 22,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1875,
+                "acceptances_count": 420,
+                "lines_suggested": 7960,
+                "lines_accepted": 752,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 41,
+                "acceptances_count": 2,
+                "lines_suggested": 98,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 314,
+                "acceptances_count": 52,
+                "lines_suggested": 1137,
+                "lines_accepted": 56,
+                "active_users": 2
+            },
+            {
+                "language": "web",
+                "editor": "emacs",
+                "suggestions_count": 60,
+                "acceptances_count": 14,
+                "lines_suggested": 128,
+                "lines_accepted": 21,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 182,
+        "total_chat_turns": 43,
+        "total_active_chat_users": 6
+    },
+    {
+        "day": "2024-03-22",
+        "total_suggestions_count": 6838,
+        "total_acceptances_count": 1744,
+        "total_lines_suggested": 13086,
+        "total_lines_accepted": 3610,
+        "total_active_users": 91,
+        "breakdown": [
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 83,
+                "acceptances_count": 8,
+                "lines_suggested": 112,
+                "lines_accepted": 11,
+                "active_users": 4
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 292,
+                "acceptances_count": 106,
+                "lines_suggested": 511,
+                "lines_accepted": 207,
+                "active_users": 13
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 154,
+                "acceptances_count": 9,
+                "lines_suggested": 455,
+                "lines_accepted": 23,
+                "active_users": 2
+            },
+            {
+                "language": "log",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 35,
+                "acceptances_count": 4,
+                "lines_suggested": 132,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "river",
+                "editor": "vscode",
+                "suggestions_count": 63,
+                "acceptances_count": 3,
+                "lines_suggested": 110,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "rmd",
+                "editor": "vscode",
+                "suggestions_count": 126,
+                "acceptances_count": 28,
+                "lines_suggested": 237,
+                "lines_accepted": 46,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "terragrunt",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 9,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 367,
+                "acceptances_count": 123,
+                "lines_suggested": 669,
+                "lines_accepted": 223,
+                "active_users": 9
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 107,
+                "acceptances_count": 31,
+                "lines_suggested": 172,
+                "lines_accepted": 65,
+                "active_users": 5
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 679,
+                "acceptances_count": 209,
+                "lines_suggested": 1438,
+                "lines_accepted": 676,
+                "active_users": 19
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 164,
+                "acceptances_count": 40,
+                "lines_suggested": 245,
+                "lines_accepted": 92,
+                "active_users": 7
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 744,
+                "acceptances_count": 273,
+                "lines_suggested": 1155,
+                "lines_accepted": 419,
+                "active_users": 12
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 171,
+                "acceptances_count": 92,
+                "lines_suggested": 1101,
+                "lines_accepted": 506,
+                "active_users": 10
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 65,
+                "acceptances_count": 13,
+                "lines_suggested": 88,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 9,
+                "lines_suggested": 22,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 9,
+                "lines_suggested": 37,
+                "lines_accepted": 10,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 49,
+                "acceptances_count": 10,
+                "lines_suggested": 93,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 14,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 52,
+                "acceptances_count": 18,
+                "lines_suggested": 65,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "julia",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 2,
+                "lines_suggested": 12,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 766,
+                "acceptances_count": 165,
+                "lines_suggested": 1532,
+                "lines_accepted": 305,
+                "active_users": 13
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 33,
+                "acceptances_count": 6,
+                "lines_suggested": 79,
+                "lines_accepted": 8,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1399,
+                "acceptances_count": 196,
+                "lines_suggested": 1876,
+                "lines_accepted": 232,
+                "active_users": 10
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 26,
+                "acceptances_count": 20,
+                "lines_suggested": 44,
+                "lines_accepted": 32,
+                "active_users": 4
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 71,
+                "acceptances_count": 16,
+                "lines_suggested": 174,
+                "lines_accepted": 56,
+                "active_users": 5
+            },
+            {
+                "language": "protocol buffer",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 2,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 3,
+                "lines_suggested": 44,
+                "lines_accepted": 38,
+                "active_users": 2
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 65,
+                "acceptances_count": 50,
+                "lines_suggested": 142,
+                "lines_accepted": 55,
+                "active_users": 4
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 2,
+                "lines_suggested": 42,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 52,
+                "acceptances_count": 12,
+                "lines_suggested": 80,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 38,
+                "acceptances_count": 4,
+                "lines_suggested": 45,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 355,
+                "acceptances_count": 82,
+                "lines_suggested": 690,
+                "lines_accepted": 256,
+                "active_users": 12
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 4,
+                "lines_suggested": 43,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 22,
+                "acceptances_count": 2,
+                "lines_suggested": 23,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 12,
+                "lines_suggested": 58,
+                "lines_accepted": 13,
+                "active_users": 4
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 224,
+                "acceptances_count": 24,
+                "lines_suggested": 322,
+                "lines_accepted": 24,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 61,
+                "acceptances_count": 29,
+                "lines_suggested": 90,
+                "lines_accepted": 29,
+                "active_users": 3
+            },
+            {
+                "language": "sql",
+                "editor": "visual_studio",
+                "suggestions_count": 12,
+                "acceptances_count": 11,
+                "lines_suggested": 13,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 6,
+                "lines_suggested": 18,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 16,
+                "acceptances_count": 4,
+                "lines_suggested": 35,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 135,
+                "acceptances_count": 47,
+                "lines_suggested": 542,
+                "lines_accepted": 68,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 12,
+                "acceptances_count": 0,
+                "lines_suggested": 31,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 115,
+                "acceptances_count": 51,
+                "lines_suggested": 287,
+                "lines_accepted": 61,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 42,
+                "acceptances_count": 3,
+                "lines_suggested": 143,
+                "lines_accepted": 3,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 57,
+        "total_chat_turns": 43,
+        "total_active_chat_users": 187
+    },
+    {
+        "day": "2024-03-23",
+        "total_suggestions_count": 4728,
+        "total_acceptances_count": 1024,
+        "total_lines_suggested": 7505,
+        "total_lines_accepted": 1416,
+        "total_active_users": 37,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 170,
+                "acceptances_count": 49,
+                "lines_suggested": 451,
+                "lines_accepted": 98,
+                "active_users": 4
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 2,
+                "lines_suggested": 23,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 17,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 33,
+                "acceptances_count": 4,
+                "lines_suggested": 78,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "rmd",
+                "editor": "vscode",
+                "suggestions_count": 142,
+                "acceptances_count": 44,
+                "lines_suggested": 272,
+                "lines_accepted": 50,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 541,
+                "acceptances_count": 156,
+                "lines_suggested": 843,
+                "lines_accepted": 197,
+                "active_users": 6
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 42,
+                "acceptances_count": 16,
+                "lines_suggested": 52,
+                "lines_accepted": 19,
+                "active_users": 3
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 123,
+                "acceptances_count": 34,
+                "lines_suggested": 150,
+                "lines_accepted": 39,
+                "active_users": 6
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 37,
+                "acceptances_count": 16,
+                "lines_suggested": 134,
+                "lines_accepted": 57,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 602,
+                "acceptances_count": 236,
+                "lines_suggested": 775,
+                "lines_accepted": 306,
+                "active_users": 6
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 117,
+                "acceptances_count": 18,
+                "lines_suggested": 261,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 6,
+                "lines_suggested": 23,
+                "lines_accepted": 13,
+                "active_users": 2
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 84,
+                "acceptances_count": 24,
+                "lines_suggested": 153,
+                "lines_accepted": 51,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 138,
+                "acceptances_count": 35,
+                "lines_suggested": 324,
+                "lines_accepted": 51,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 2,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 55,
+                "acceptances_count": 13,
+                "lines_suggested": 91,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 124,
+                "acceptances_count": 39,
+                "lines_suggested": 177,
+                "lines_accepted": 63,
+                "active_users": 7
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 6,
+                "lines_suggested": 144,
+                "lines_accepted": 14,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2108,
+                "acceptances_count": 261,
+                "lines_suggested": 2888,
+                "lines_accepted": 281,
+                "active_users": 5
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 132,
+                "acceptances_count": 30,
+                "lines_suggested": 266,
+                "lines_accepted": 66,
+                "active_users": 5
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 15,
+                "acceptances_count": 2,
+                "lines_suggested": 16,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 16,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 5,
+                "lines_suggested": 32,
+                "lines_accepted": 8,
+                "active_users": 4
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 26,
+                "acceptances_count": 4,
+                "lines_suggested": 34,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 26,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 32,
+                "acceptances_count": 15,
+                "lines_suggested": 66,
+                "lines_accepted": 29,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 4,
+                "lines_suggested": 14,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "php",
+                "editor": "neovim",
+                "suggestions_count": 13,
+                "acceptances_count": 0,
+                "lines_suggested": 28,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 11,
+                "acceptances_count": 1,
+                "lines_suggested": 110,
+                "lines_accepted": 1,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 180,
+        "total_chat_turns": 196,
+        "total_active_chat_users": 146
+    },
+    {
+        "day": "2024-03-24",
+        "total_suggestions_count": 5479,
+        "total_acceptances_count": 1482,
+        "total_lines_suggested": 12599,
+        "total_lines_accepted": 2429,
+        "total_active_users": 35,
+        "breakdown": [
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 4,
+                "lines_suggested": 10,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 25,
+                "acceptances_count": 15,
+                "lines_suggested": 26,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "vscode",
+                "suggestions_count": 58,
+                "acceptances_count": 48,
+                "lines_suggested": 196,
+                "lines_accepted": 61,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "river",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 1,
+                "lines_suggested": 47,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "rmd",
+                "editor": "vscode",
+                "suggestions_count": 171,
+                "acceptances_count": 55,
+                "lines_suggested": 325,
+                "lines_accepted": 92,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 21,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 708,
+                "acceptances_count": 272,
+                "lines_suggested": 1193,
+                "lines_accepted": 448,
+                "active_users": 6
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 50,
+                "acceptances_count": 11,
+                "lines_suggested": 83,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 48,
+                "acceptances_count": 16,
+                "lines_suggested": 60,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 143,
+                "acceptances_count": 30,
+                "lines_suggested": 225,
+                "lines_accepted": 46,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 234,
+                "acceptances_count": 51,
+                "lines_suggested": 314,
+                "lines_accepted": 57,
+                "active_users": 6
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 328,
+                "acceptances_count": 95,
+                "lines_suggested": 523,
+                "lines_accepted": 140,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 129,
+                "acceptances_count": 29,
+                "lines_suggested": 252,
+                "lines_accepted": 42,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 9,
+                "lines_suggested": 29,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "julia",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 348,
+                "acceptances_count": 116,
+                "lines_suggested": 598,
+                "lines_accepted": 261,
+                "active_users": 6
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 143,
+                "acceptances_count": 9,
+                "lines_suggested": 276,
+                "lines_accepted": 18,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1169,
+                "acceptances_count": 312,
+                "lines_suggested": 1699,
+                "lines_accepted": 384,
+                "active_users": 3
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 80,
+                "acceptances_count": 17,
+                "lines_suggested": 264,
+                "lines_accepted": 33,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 440,
+                "acceptances_count": 139,
+                "lines_suggested": 1463,
+                "lines_accepted": 340,
+                "active_users": 4
+            },
+            {
+                "language": "vue",
+                "editor": "vscode",
+                "suggestions_count": 39,
+                "acceptances_count": 15,
+                "lines_suggested": 48,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "blade",
+                "editor": "vscode",
+                "suggestions_count": 59,
+                "acceptances_count": 6,
+                "lines_suggested": 90,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 19,
+                "acceptances_count": 3,
+                "lines_suggested": 28,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 58,
+                "acceptances_count": 3,
+                "lines_suggested": 80,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 10,
+                "lines_suggested": 184,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 4,
+                "lines_suggested": 95,
+                "lines_accepted": 6,
+                "active_users": 3
+            },
+            {
+                "language": "editorconfig",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 58,
+                "acceptances_count": 16,
+                "lines_suggested": 73,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 19,
+                "acceptances_count": 8,
+                "lines_suggested": 20,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 10,
+                "acceptances_count": 1,
+                "lines_suggested": 10,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 57,
+                "acceptances_count": 18,
+                "lines_suggested": 66,
+                "lines_accepted": 20,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 24,
+                "acceptances_count": 6,
+                "lines_suggested": 37,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 886,
+                "acceptances_count": 162,
+                "lines_suggested": 4221,
+                "lines_accepted": 330,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 161,
+        "total_chat_turns": 88,
+        "total_active_chat_users": 141
+    },
+    {
+        "day": "2024-03-25",
+        "total_suggestions_count": 8703,
+        "total_acceptances_count": 2324,
+        "total_lines_suggested": 14763,
+        "total_lines_accepted": 3990,
+        "total_active_users": 99,
+        "breakdown": [
+            {
+                "language": "fsharp",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 20,
+                "lines_suggested": 132,
+                "lines_accepted": 75,
+                "active_users": 2
+            },
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 41,
+                "acceptances_count": 1,
+                "lines_suggested": 56,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 23,
+                "lines_suggested": 94,
+                "lines_accepted": 31,
+                "active_users": 6
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 3,
+                "lines_suggested": 68,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 100,
+                "acceptances_count": 6,
+                "lines_suggested": 167,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1100,
+                "acceptances_count": 378,
+                "lines_suggested": 1847,
+                "lines_accepted": 710,
+                "active_users": 10
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 239,
+                "acceptances_count": 67,
+                "lines_suggested": 354,
+                "lines_accepted": 93,
+                "active_users": 9
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 616,
+                "acceptances_count": 250,
+                "lines_suggested": 1356,
+                "lines_accepted": 657,
+                "active_users": 19
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 893,
+                "acceptances_count": 272,
+                "lines_suggested": 1146,
+                "lines_accepted": 304,
+                "active_users": 11
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 4,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 317,
+                "acceptances_count": 100,
+                "lines_suggested": 555,
+                "lines_accepted": 163,
+                "active_users": 13
+            },
+            {
+                "language": "c",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 4,
+                "lines_suggested": 15,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 100,
+                "acceptances_count": 58,
+                "lines_suggested": 261,
+                "lines_accepted": 166,
+                "active_users": 5
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 403,
+                "acceptances_count": 157,
+                "lines_suggested": 634,
+                "lines_accepted": 208,
+                "active_users": 5
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 19,
+                "acceptances_count": 14,
+                "lines_suggested": 61,
+                "lines_accepted": 33,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 38,
+                "acceptances_count": 9,
+                "lines_suggested": 50,
+                "lines_accepted": 13,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1389,
+                "acceptances_count": 308,
+                "lines_suggested": 2062,
+                "lines_accepted": 503,
+                "active_users": 13
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 181,
+                "acceptances_count": 15,
+                "lines_suggested": 356,
+                "lines_accepted": 23,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1914,
+                "acceptances_count": 308,
+                "lines_suggested": 2902,
+                "lines_accepted": 374,
+                "active_users": 17
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 125,
+                "acceptances_count": 41,
+                "lines_suggested": 334,
+                "lines_accepted": 116,
+                "active_users": 7
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "csv",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 69,
+                "acceptances_count": 46,
+                "lines_suggested": 93,
+                "lines_accepted": 60,
+                "active_users": 3
+            },
+            {
+                "language": "gradle",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 45,
+                "acceptances_count": 2,
+                "lines_suggested": 108,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 1,
+                "lines_suggested": 14,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 16,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 257,
+                "acceptances_count": 25,
+                "lines_suggested": 477,
+                "lines_accepted": 25,
+                "active_users": 5
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 121,
+                "acceptances_count": 32,
+                "lines_suggested": 236,
+                "lines_accepted": 109,
+                "active_users": 6
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 57,
+                "acceptances_count": 16,
+                "lines_suggested": 81,
+                "lines_accepted": 28,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 26,
+                "acceptances_count": 3,
+                "lines_suggested": 33,
+                "lines_accepted": 5,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 2,
+                "lines_suggested": 10,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 22,
+                "acceptances_count": 6,
+                "lines_suggested": 35,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "visual_studio",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 14,
+                "acceptances_count": 4,
+                "lines_suggested": 36,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 25,
+                "acceptances_count": 4,
+                "lines_suggested": 40,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 93,
+                "acceptances_count": 32,
+                "lines_suggested": 410,
+                "lines_accepted": 82,
+                "active_users": 2
+            },
+            {
+                "language": "sql",
+                "editor": "jetbrains",
+                "suggestions_count": 11,
+                "acceptances_count": 3,
+                "lines_suggested": 12,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 14,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "eruby",
+                "editor": "neovim",
+                "suggestions_count": 15,
+                "acceptances_count": 6,
+                "lines_suggested": 44,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 207,
+                "acceptances_count": 92,
+                "lines_suggested": 524,
+                "lines_accepted": 124,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "neovim",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 17,
+                "acceptances_count": 2,
+                "lines_suggested": 46,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "emacs",
+                "suggestions_count": 11,
+                "acceptances_count": 6,
+                "lines_suggested": 18,
+                "lines_accepted": 9,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 71,
+        "total_chat_turns": 159,
+        "total_active_chat_users": 53
+    },
+    {
+        "day": "2024-03-26",
+        "total_suggestions_count": 9119,
+        "total_acceptances_count": 2298,
+        "total_lines_suggested": 16524,
+        "total_lines_accepted": 4566,
+        "total_active_users": 118,
+        "breakdown": [
+            {
+                "language": "concourse-pipeline-yaml",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 2,
+                "lines_suggested": 7,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 26,
+                "lines_suggested": 162,
+                "lines_accepted": 75,
+                "active_users": 2
+            },
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 51,
+                "acceptances_count": 1,
+                "lines_suggested": 61,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "git-rebase",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 224,
+                "acceptances_count": 63,
+                "lines_suggested": 496,
+                "lines_accepted": 169,
+                "active_users": 11
+            },
+            {
+                "language": "go.mod",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 1,
+                "lines_suggested": 15,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 50,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 120,
+                "acceptances_count": 11,
+                "lines_suggested": 161,
+                "lines_accepted": 32,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 11,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 51,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 41,
+                "acceptances_count": 3,
+                "lines_suggested": 47,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 0,
+                "lines_suggested": 17,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 696,
+                "acceptances_count": 172,
+                "lines_suggested": 1170,
+                "lines_accepted": 314,
+                "active_users": 11
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 498,
+                "acceptances_count": 113,
+                "lines_suggested": 801,
+                "lines_accepted": 190,
+                "active_users": 8
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 1103,
+                "acceptances_count": 393,
+                "lines_suggested": 2245,
+                "lines_accepted": 930,
+                "active_users": 30
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 367,
+                "acceptances_count": 71,
+                "lines_suggested": 572,
+                "lines_accepted": 93,
+                "active_users": 11
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 331,
+                "acceptances_count": 106,
+                "lines_suggested": 421,
+                "lines_accepted": 138,
+                "active_users": 12
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 10,
+                "lines_suggested": 20,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 201,
+                "acceptances_count": 105,
+                "lines_suggested": 659,
+                "lines_accepted": 409,
+                "active_users": 12
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 88,
+                "acceptances_count": 28,
+                "lines_suggested": 133,
+                "lines_accepted": 46,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 30,
+                "acceptances_count": 18,
+                "lines_suggested": 88,
+                "lines_accepted": 64,
+                "active_users": 4
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 120,
+                "acceptances_count": 50,
+                "lines_suggested": 172,
+                "lines_accepted": 64,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 2014,
+                "acceptances_count": 545,
+                "lines_suggested": 3360,
+                "lines_accepted": 961,
+                "active_users": 14
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 173,
+                "acceptances_count": 34,
+                "lines_suggested": 299,
+                "lines_accepted": 53,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1174,
+                "acceptances_count": 130,
+                "lines_suggested": 1795,
+                "lines_accepted": 146,
+                "active_users": 15
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 81,
+                "acceptances_count": 25,
+                "lines_suggested": 194,
+                "lines_accepted": 55,
+                "active_users": 11
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 4,
+                "lines_suggested": 38,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "csv",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 33,
+                "lines_suggested": 51,
+                "lines_accepted": 34,
+                "active_users": 2
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 11,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 82,
+                "acceptances_count": 12,
+                "lines_suggested": 192,
+                "lines_accepted": 63,
+                "active_users": 6
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 177,
+                "acceptances_count": 28,
+                "lines_suggested": 253,
+                "lines_accepted": 46,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 103,
+                "acceptances_count": 4,
+                "lines_suggested": 245,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 312,
+                "acceptances_count": 101,
+                "lines_suggested": 547,
+                "lines_accepted": 209,
+                "active_users": 15
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 67,
+                "acceptances_count": 26,
+                "lines_suggested": 136,
+                "lines_accepted": 45,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 138,
+                "acceptances_count": 18,
+                "lines_suggested": 333,
+                "lines_accepted": 24,
+                "active_users": 7
+            },
+            {
+                "language": "editorconfig",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 3,
+                "lines_suggested": 36,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 97,
+                "acceptances_count": 13,
+                "lines_suggested": 200,
+                "lines_accepted": 43,
+                "active_users": 2
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 41,
+                "acceptances_count": 5,
+                "lines_suggested": 46,
+                "lines_accepted": 5,
+                "active_users": 3
+            },
+            {
+                "language": "python",
+                "editor": "visual_studio",
+                "suggestions_count": 4,
+                "acceptances_count": 2,
+                "lines_suggested": 13,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 107,
+                "acceptances_count": 39,
+                "lines_suggested": 398,
+                "lines_accepted": 126,
+                "active_users": 4
+            },
+            {
+                "language": "sql",
+                "editor": "visual_studio",
+                "suggestions_count": 7,
+                "acceptances_count": 5,
+                "lines_suggested": 13,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 32,
+                "acceptances_count": 13,
+                "lines_suggested": 60,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 25,
+                "acceptances_count": 6,
+                "lines_suggested": 63,
+                "lines_accepted": 25,
+                "active_users": 3
+            },
+            {
+                "language": "c",
+                "editor": "jetbrains",
+                "suggestions_count": 165,
+                "acceptances_count": 30,
+                "lines_suggested": 321,
+                "lines_accepted": 62,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 128,
+                "acceptances_count": 32,
+                "lines_suggested": 418,
+                "lines_accepted": 56,
+                "active_users": 3
+            },
+            {
+                "language": "eruby",
+                "editor": "neovim",
+                "suggestions_count": 5,
+                "acceptances_count": 3,
+                "lines_suggested": 9,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 20,
+                "acceptances_count": 6,
+                "lines_suggested": 48,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 28,
+                "lines_accepted": 0,
+                "active_users": 1
+            }
+        ],
+        "total_chat_acceptances": 118,
+        "total_chat_turns": 192,
+        "total_active_chat_users": 34
+    },
+    {
+        "day": "2024-03-27",
+        "total_suggestions_count": 11575,
+        "total_acceptances_count": 3104,
+        "total_lines_suggested": 25880,
+        "total_lines_accepted": 6335,
+        "total_active_users": 118,
+        "breakdown": [
+            {
+                "language": "csv (pipe)",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "django-html",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "es",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "vscode",
+                "suggestions_count": 125,
+                "acceptances_count": 38,
+                "lines_suggested": 182,
+                "lines_accepted": 43,
+                "active_users": 2
+            },
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 40,
+                "acceptances_count": 2,
+                "lines_suggested": 52,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 83,
+                "acceptances_count": 26,
+                "lines_suggested": 125,
+                "lines_accepted": 39,
+                "active_users": 7
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 2,
+                "lines_suggested": 16,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 100,
+                "acceptances_count": 3,
+                "lines_suggested": 127,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 15,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 52,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 13,
+                "acceptances_count": 1,
+                "lines_suggested": 13,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 3,
+                "lines_suggested": 21,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "restructuredtext",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "river",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 0,
+                "lines_suggested": 42,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ssh_config",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1282,
+                "acceptances_count": 475,
+                "lines_suggested": 2417,
+                "lines_accepted": 976,
+                "active_users": 11
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 260,
+                "acceptances_count": 50,
+                "lines_suggested": 537,
+                "lines_accepted": 77,
+                "active_users": 9
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 744,
+                "acceptances_count": 232,
+                "lines_suggested": 1569,
+                "lines_accepted": 568,
+                "active_users": 25
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 331,
+                "acceptances_count": 82,
+                "lines_suggested": 561,
+                "lines_accepted": 145,
+                "active_users": 10
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 1431,
+                "acceptances_count": 510,
+                "lines_suggested": 2233,
+                "lines_accepted": 911,
+                "active_users": 18
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 218,
+                "acceptances_count": 86,
+                "lines_suggested": 1219,
+                "lines_accepted": 494,
+                "active_users": 14
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 5,
+                "lines_suggested": 12,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 20,
+                "lines_suggested": 87,
+                "lines_accepted": 20,
+                "active_users": 4
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 169,
+                "acceptances_count": 40,
+                "lines_suggested": 369,
+                "lines_accepted": 105,
+                "active_users": 3
+            },
+            {
+                "language": "julia",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 21,
+                "lines_suggested": 73,
+                "lines_accepted": 24,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 15,
+                "acceptances_count": 9,
+                "lines_suggested": 41,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 2021,
+                "acceptances_count": 580,
+                "lines_suggested": 3895,
+                "lines_accepted": 1157,
+                "active_users": 12
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 183,
+                "acceptances_count": 17,
+                "lines_suggested": 317,
+                "lines_accepted": 22,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1394,
+                "acceptances_count": 246,
+                "lines_suggested": 2026,
+                "lines_accepted": 298,
+                "active_users": 21
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 2,
+                "lines_suggested": 19,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 12,
+                "lines_suggested": 64,
+                "lines_accepted": 46,
+                "active_users": 5
+            },
+            {
+                "language": "protocol buffer",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 1,
+                "lines_suggested": 16,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 4,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "vue",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 7,
+                "lines_suggested": 29,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 5,
+                "lines_suggested": 168,
+                "lines_accepted": 9,
+                "active_users": 3
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 73,
+                "acceptances_count": 10,
+                "lines_suggested": 92,
+                "lines_accepted": 10,
+                "active_users": 4
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 117,
+                "acceptances_count": 24,
+                "lines_suggested": 211,
+                "lines_accepted": 36,
+                "active_users": 3
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 76,
+                "acceptances_count": 5,
+                "lines_suggested": 143,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 653,
+                "acceptances_count": 223,
+                "lines_suggested": 1516,
+                "lines_accepted": 599,
+                "active_users": 13
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 92,
+                "acceptances_count": 22,
+                "lines_suggested": 211,
+                "lines_accepted": 32,
+                "active_users": 3
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 22,
+                "acceptances_count": 1,
+                "lines_suggested": 25,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 4,
+                "lines_suggested": 15,
+                "lines_accepted": 5,
+                "active_users": 5
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 85,
+                "acceptances_count": 31,
+                "lines_suggested": 121,
+                "lines_accepted": 43,
+                "active_users": 3
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 21,
+                "acceptances_count": 3,
+                "lines_suggested": 44,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 59,
+                "acceptances_count": 23,
+                "lines_suggested": 139,
+                "lines_accepted": 65,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 142,
+                "acceptances_count": 24,
+                "lines_suggested": 170,
+                "lines_accepted": 24,
+                "active_users": 3
+            },
+            {
+                "language": "c",
+                "editor": "jetbrains",
+                "suggestions_count": 68,
+                "acceptances_count": 10,
+                "lines_suggested": 119,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 70,
+                "acceptances_count": 6,
+                "lines_suggested": 122,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 16,
+                "acceptances_count": 7,
+                "lines_suggested": 82,
+                "lines_accepted": 27,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 72,
+                "acceptances_count": 38,
+                "lines_suggested": 261,
+                "lines_accepted": 80,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "neovim",
+                "suggestions_count": 14,
+                "acceptances_count": 8,
+                "lines_suggested": 21,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1095,
+                "acceptances_count": 171,
+                "lines_suggested": 5886,
+                "lines_accepted": 373,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 54,
+                "acceptances_count": 2,
+                "lines_suggested": 184,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 40,
+                "acceptances_count": 11,
+                "lines_suggested": 101,
+                "lines_accepted": 13,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 17,
+                "acceptances_count": 0,
+                "lines_suggested": 62,
+                "lines_accepted": 0,
+                "active_users": 1
+            }
+        ],
+        "total_chat_acceptances": 132,
+        "total_chat_turns": 36,
+        "total_active_chat_users": 162
+    },
+    {
+        "day": "2024-03-28",
+        "total_suggestions_count": 9325,
+        "total_acceptances_count": 2149,
+        "total_lines_suggested": 27422,
+        "total_lines_accepted": 4097,
+        "total_active_users": 106,
+        "breakdown": [
+            {
+                "language": "fsharp",
+                "editor": "vscode",
+                "suggestions_count": 45,
+                "acceptances_count": 7,
+                "lines_suggested": 56,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 4,
+                "lines_suggested": 97,
+                "lines_accepted": 4,
+                "active_users": 4
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 252,
+                "acceptances_count": 62,
+                "lines_suggested": 499,
+                "lines_accepted": 124,
+                "active_users": 6
+            },
+            {
+                "language": "java-properties",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 23,
+                "lines_suggested": 52,
+                "lines_accepted": 40,
+                "active_users": 2
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 40,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 51,
+                "acceptances_count": 1,
+                "lines_suggested": 135,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 13,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "tsv",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 401,
+                "acceptances_count": 98,
+                "lines_suggested": 701,
+                "lines_accepted": 163,
+                "active_users": 10
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 99,
+                "acceptances_count": 29,
+                "lines_suggested": 167,
+                "lines_accepted": 45,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 1167,
+                "acceptances_count": 354,
+                "lines_suggested": 2354,
+                "lines_accepted": 827,
+                "active_users": 23
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 306,
+                "acceptances_count": 80,
+                "lines_suggested": 559,
+                "lines_accepted": 115,
+                "active_users": 12
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 5,
+                "lines_suggested": 40,
+                "lines_accepted": 19,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 648,
+                "acceptances_count": 234,
+                "lines_suggested": 1053,
+                "lines_accepted": 415,
+                "active_users": 15
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 117,
+                "acceptances_count": 59,
+                "lines_suggested": 387,
+                "lines_accepted": 207,
+                "active_users": 6
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 70,
+                "acceptances_count": 25,
+                "lines_suggested": 174,
+                "lines_accepted": 44,
+                "active_users": 4
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 83,
+                "acceptances_count": 23,
+                "lines_suggested": 180,
+                "lines_accepted": 60,
+                "active_users": 6
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 3,
+                "lines_suggested": 116,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 22,
+                "acceptances_count": 4,
+                "lines_suggested": 35,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 553,
+                "acceptances_count": 169,
+                "lines_suggested": 1028,
+                "lines_accepted": 349,
+                "active_users": 11
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 52,
+                "acceptances_count": 5,
+                "lines_suggested": 71,
+                "lines_accepted": 7,
+                "active_users": 4
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1466,
+                "acceptances_count": 136,
+                "lines_suggested": 2120,
+                "lines_accepted": 141,
+                "active_users": 21
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 1,
+                "lines_suggested": 20,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 147,
+                "acceptances_count": 37,
+                "lines_suggested": 241,
+                "lines_accepted": 44,
+                "active_users": 11
+            },
+            {
+                "language": "cmake",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 7,
+                "lines_suggested": 11,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 3,
+                "lines_suggested": 69,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "csv",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 39,
+                "acceptances_count": 34,
+                "lines_suggested": 41,
+                "lines_accepted": 34,
+                "active_users": 4
+            },
+            {
+                "language": "gradle",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 21,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 1,
+                "lines_suggested": 20,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 3,
+                "lines_suggested": 6,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 3,
+                "lines_suggested": 25,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 45,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 9,
+                "lines_suggested": 129,
+                "lines_accepted": 9,
+                "active_users": 4
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 191,
+                "acceptances_count": 57,
+                "lines_suggested": 660,
+                "lines_accepted": 216,
+                "active_users": 9
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 94,
+                "acceptances_count": 21,
+                "lines_suggested": 210,
+                "lines_accepted": 32,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 3,
+                "lines_suggested": 18,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 13,
+                "acceptances_count": 4,
+                "lines_suggested": 16,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 89,
+                "acceptances_count": 12,
+                "lines_suggested": 119,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 55,
+                "acceptances_count": 21,
+                "lines_suggested": 63,
+                "lines_accepted": 26,
+                "active_users": 3
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dtd",
+                "editor": "jetbrains",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 30,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 135,
+                "acceptances_count": 16,
+                "lines_suggested": 205,
+                "lines_accepted": 27,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 24,
+                "acceptances_count": 0,
+                "lines_suggested": 25,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 64,
+                "acceptances_count": 14,
+                "lines_suggested": 102,
+                "lines_accepted": 16,
+                "active_users": 3
+            },
+            {
+                "language": "c",
+                "editor": "jetbrains",
+                "suggestions_count": 29,
+                "acceptances_count": 4,
+                "lines_suggested": 36,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 21,
+                "acceptances_count": 10,
+                "lines_suggested": 49,
+                "lines_accepted": 25,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 8,
+                "acceptances_count": 3,
+                "lines_suggested": 11,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 18,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "eruby",
+                "editor": "neovim",
+                "suggestions_count": 13,
+                "acceptances_count": 3,
+                "lines_suggested": 118,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 6,
+                "acceptances_count": 5,
+                "lines_suggested": 11,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 2438,
+                "acceptances_count": 469,
+                "lines_suggested": 13138,
+                "lines_accepted": 815,
+                "active_users": 2
+            },
+            {
+                "language": "css",
+                "editor": "neovim",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 46,
+                "acceptances_count": 8,
+                "lines_suggested": 136,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 194,
+                "acceptances_count": 74,
+                "lines_suggested": 1874,
+                "lines_accepted": 182,
+                "active_users": 3
+            }
+        ],
+        "total_chat_acceptances": 108,
+        "total_chat_turns": 118,
+        "total_active_chat_users": 5
+    },
+    {
+        "day": "2024-03-30",
+        "total_suggestions_count": 5993,
+        "total_acceptances_count": 1523,
+        "total_lines_suggested": 15527,
+        "total_lines_accepted": 2709,
+        "total_active_users": 33,
+        "breakdown": [
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 1,
+                "lines_suggested": 25,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 238,
+                "acceptances_count": 36,
+                "lines_suggested": 378,
+                "lines_accepted": 72,
+                "active_users": 4
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 9,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 636,
+                "acceptances_count": 196,
+                "lines_suggested": 993,
+                "lines_accepted": 317,
+                "active_users": 3
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 59,
+                "acceptances_count": 8,
+                "lines_suggested": 70,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 347,
+                "acceptances_count": 119,
+                "lines_suggested": 563,
+                "lines_accepted": 292,
+                "active_users": 7
+            },
+            {
+                "language": "lua",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 3,
+                "lines_suggested": 23,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 121,
+                "acceptances_count": 16,
+                "lines_suggested": 139,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 862,
+                "acceptances_count": 321,
+                "lines_suggested": 1696,
+                "lines_accepted": 765,
+                "active_users": 6
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 60,
+                "acceptances_count": 6,
+                "lines_suggested": 87,
+                "lines_accepted": 12,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1681,
+                "acceptances_count": 392,
+                "lines_suggested": 2939,
+                "lines_accepted": 532,
+                "active_users": 6
+            },
+            {
+                "language": "tex",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 118,
+                "acceptances_count": 19,
+                "lines_suggested": 235,
+                "lines_accepted": 29,
+                "active_users": 4
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 3,
+                "lines_suggested": 12,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 1,
+                "lines_suggested": 23,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 2,
+                "lines_suggested": 12,
+                "lines_accepted": 3,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 93,
+                "acceptances_count": 10,
+                "lines_suggested": 225,
+                "lines_accepted": 10,
+                "active_users": 4
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 2,
+                "lines_suggested": 46,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 31,
+                "acceptances_count": 0,
+                "lines_suggested": 35,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 129,
+                "acceptances_count": 75,
+                "lines_suggested": 184,
+                "lines_accepted": 99,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 20,
+                "acceptances_count": 11,
+                "lines_suggested": 41,
+                "lines_accepted": 25,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1380,
+                "acceptances_count": 294,
+                "lines_suggested": 7287,
+                "lines_accepted": 506,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 49,
+                "acceptances_count": 3,
+                "lines_suggested": 291,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 13,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 47,
+                "acceptances_count": 1,
+                "lines_suggested": 162,
+                "lines_accepted": 1,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 39,
+        "total_chat_turns": 96,
+        "total_active_chat_users": 9
+    },
+    {
+        "day": "2024-03-31",
+        "total_suggestions_count": 6995,
+        "total_acceptances_count": 1859,
+        "total_lines_suggested": 17328,
+        "total_lines_accepted": 3044,
+        "total_active_users": 35,
+        "breakdown": [
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 2,
+                "lines_suggested": 21,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 71,
+                "acceptances_count": 25,
+                "lines_suggested": 156,
+                "lines_accepted": 49,
+                "active_users": 3
+            },
+            {
+                "language": "gotemplate",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 2,
+                "lines_suggested": 16,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 189,
+                "acceptances_count": 15,
+                "lines_suggested": 387,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "sas",
+                "editor": "vscode",
+                "suggestions_count": 71,
+                "acceptances_count": 14,
+                "lines_suggested": 116,
+                "lines_accepted": 17,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 223,
+                "acceptances_count": 72,
+                "lines_suggested": 394,
+                "lines_accepted": 108,
+                "active_users": 5
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 82,
+                "acceptances_count": 5,
+                "lines_suggested": 102,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 759,
+                "acceptances_count": 256,
+                "lines_suggested": 1614,
+                "lines_accepted": 385,
+                "active_users": 9
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 63,
+                "acceptances_count": 32,
+                "lines_suggested": 100,
+                "lines_accepted": 32,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 413,
+                "acceptances_count": 106,
+                "lines_suggested": 650,
+                "lines_accepted": 159,
+                "active_users": 6
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "clojure",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 59,
+                "acceptances_count": 15,
+                "lines_suggested": 73,
+                "lines_accepted": 19,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1077,
+                "acceptances_count": 389,
+                "lines_suggested": 2150,
+                "lines_accepted": 807,
+                "active_users": 9
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 55,
+                "acceptances_count": 4,
+                "lines_suggested": 116,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1644,
+                "acceptances_count": 402,
+                "lines_suggested": 2405,
+                "lines_accepted": 428,
+                "active_users": 6
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 119,
+                "acceptances_count": 11,
+                "lines_suggested": 327,
+                "lines_accepted": 17,
+                "active_users": 4
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 2,
+                "lines_suggested": 12,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 5,
+                "lines_suggested": 67,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "vscode",
+                "suggestions_count": 28,
+                "acceptances_count": 1,
+                "lines_suggested": 45,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 0,
+                "lines_suggested": 104,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 125,
+                "acceptances_count": 34,
+                "lines_suggested": 215,
+                "lines_accepted": 69,
+                "active_users": 3
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 1,
+                "lines_suggested": 16,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 2,
+                "lines_suggested": 2,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 5,
+                "lines_suggested": 26,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 31,
+                "acceptances_count": 9,
+                "lines_suggested": 102,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 379,
+                "acceptances_count": 94,
+                "lines_suggested": 1166,
+                "lines_accepted": 190,
+                "active_users": 3
+            },
+            {
+                "language": "vim",
+                "editor": "neovim",
+                "suggestions_count": 11,
+                "acceptances_count": 2,
+                "lines_suggested": 27,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "lua",
+                "editor": "neovim",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 99,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1215,
+                "acceptances_count": 282,
+                "lines_suggested": 5637,
+                "lines_accepted": 585,
+                "active_users": 2
+            },
+            {
+                "language": "css",
+                "editor": "neovim",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 50,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 55,
+                "acceptances_count": 17,
+                "lines_suggested": 174,
+                "lines_accepted": 29,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 153,
+                "acceptances_count": 55,
+                "lines_suggested": 946,
+                "lines_accepted": 79,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 125,
+        "total_chat_turns": 19,
+        "total_active_chat_users": 54
+    },
+    {
+        "day": "2024-04-01",
+        "total_suggestions_count": 6819,
+        "total_acceptances_count": 1815,
+        "total_lines_suggested": 29475,
+        "total_lines_accepted": 3169,
+        "total_active_users": 70,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 434,
+                "acceptances_count": 122,
+                "lines_suggested": 750,
+                "lines_accepted": 185,
+                "active_users": 5
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 1,
+                "lines_suggested": 11,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "jade",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "mermaid",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "objective-cpp",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 11,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 386,
+                "acceptances_count": 95,
+                "lines_suggested": 565,
+                "lines_accepted": 164,
+                "active_users": 9
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 47,
+                "acceptances_count": 11,
+                "lines_suggested": 80,
+                "lines_accepted": 14,
+                "active_users": 5
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 368,
+                "acceptances_count": 99,
+                "lines_suggested": 721,
+                "lines_accepted": 209,
+                "active_users": 15
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 471,
+                "acceptances_count": 120,
+                "lines_suggested": 648,
+                "lines_accepted": 169,
+                "active_users": 9
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 309,
+                "acceptances_count": 111,
+                "lines_suggested": 591,
+                "lines_accepted": 217,
+                "active_users": 7
+            },
+            {
+                "language": "perl",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 0,
+                "lines_suggested": 24,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 2,
+                "lines_suggested": 50,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "clojure",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 259,
+                "acceptances_count": 76,
+                "lines_suggested": 341,
+                "lines_accepted": 92,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 3,
+                "lines_suggested": 73,
+                "lines_accepted": 6,
+                "active_users": 3
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 47,
+                "acceptances_count": 6,
+                "lines_suggested": 104,
+                "lines_accepted": 14,
+                "active_users": 3
+            },
+            {
+                "language": "julia",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1391,
+                "acceptances_count": 411,
+                "lines_suggested": 2420,
+                "lines_accepted": 742,
+                "active_users": 13
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 4,
+                "lines_suggested": 43,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1326,
+                "acceptances_count": 234,
+                "lines_suggested": 1936,
+                "lines_accepted": 262,
+                "active_users": 8
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 58,
+                "acceptances_count": 7,
+                "lines_suggested": 199,
+                "lines_accepted": 29,
+                "active_users": 4
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 77,
+                "acceptances_count": 35,
+                "lines_suggested": 614,
+                "lines_accepted": 211,
+                "active_users": 3
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 21,
+                "lines_suggested": 71,
+                "lines_accepted": 22,
+                "active_users": 3
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 42,
+                "acceptances_count": 8,
+                "lines_suggested": 69,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 64,
+                "acceptances_count": 14,
+                "lines_suggested": 99,
+                "lines_accepted": 14,
+                "active_users": 4
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 7,
+                "lines_suggested": 15664,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 303,
+                "acceptances_count": 91,
+                "lines_suggested": 557,
+                "lines_accepted": 145,
+                "active_users": 11
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 5,
+                "lines_suggested": 31,
+                "lines_accepted": 5,
+                "active_users": 4
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 9,
+                "lines_suggested": 73,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "code++.ini",
+                "editor": "visual_studio",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 29,
+                "acceptances_count": 3,
+                "lines_suggested": 248,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 95,
+                "acceptances_count": 63,
+                "lines_suggested": 99,
+                "lines_accepted": 66,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 2,
+                "lines_suggested": 4,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 409,
+                "acceptances_count": 113,
+                "lines_suggested": 1278,
+                "lines_accepted": 229,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 73,
+                "acceptances_count": 21,
+                "lines_suggested": 253,
+                "lines_accepted": 32,
+                "active_users": 2
+            },
+            {
+                "language": "css",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 5,
+                "acceptances_count": 4,
+                "lines_suggested": 5,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 88,
+                "acceptances_count": 20,
+                "lines_suggested": 380,
+                "lines_accepted": 60,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 10,
+                "acceptances_count": 6,
+                "lines_suggested": 14,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 208,
+                "acceptances_count": 87,
+                "lines_suggested": 1398,
+                "lines_accepted": 230,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 42,
+        "total_chat_turns": 194,
+        "total_active_chat_users": 44
+    },
+    {
+        "day": "2024-04-02",
+        "total_suggestions_count": 8476,
+        "total_acceptances_count": 2237,
+        "total_lines_suggested": 14464,
+        "total_lines_accepted": 3768,
+        "total_active_users": 106,
+        "breakdown": [
+            {
+                "language": "aspnetcorerazor",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 3,
+                "lines_suggested": 27,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 17,
+                "lines_suggested": 119,
+                "lines_accepted": 21,
+                "active_users": 4
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1726,
+                "acceptances_count": 535,
+                "lines_suggested": 2611,
+                "lines_accepted": 843,
+                "active_users": 19
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 64,
+                "acceptances_count": 40,
+                "lines_suggested": 86,
+                "lines_accepted": 54,
+                "active_users": 3
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 410,
+                "acceptances_count": 136,
+                "lines_suggested": 916,
+                "lines_accepted": 305,
+                "active_users": 20
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 623,
+                "acceptances_count": 198,
+                "lines_suggested": 896,
+                "lines_accepted": 226,
+                "active_users": 14
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 568,
+                "acceptances_count": 203,
+                "lines_suggested": 869,
+                "lines_accepted": 327,
+                "active_users": 15
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 66,
+                "acceptances_count": 20,
+                "lines_suggested": 394,
+                "lines_accepted": 196,
+                "active_users": 6
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 192,
+                "acceptances_count": 52,
+                "lines_suggested": 337,
+                "lines_accepted": 75,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 11,
+                "lines_suggested": 42,
+                "lines_accepted": 20,
+                "active_users": 4
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 13,
+                "lines_suggested": 340,
+                "lines_accepted": 31,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 78,
+                "acceptances_count": 12,
+                "lines_suggested": 99,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1293,
+                "acceptances_count": 345,
+                "lines_suggested": 2094,
+                "lines_accepted": 602,
+                "active_users": 20
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 98,
+                "acceptances_count": 14,
+                "lines_suggested": 248,
+                "lines_accepted": 42,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1904,
+                "acceptances_count": 276,
+                "lines_suggested": 2753,
+                "lines_accepted": 316,
+                "active_users": 16
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 2,
+                "lines_suggested": 46,
+                "lines_accepted": 17,
+                "active_users": 3
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 100,
+                "acceptances_count": 15,
+                "lines_suggested": 238,
+                "lines_accepted": 28,
+                "active_users": 6
+            },
+            {
+                "language": "protocol buffer",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 81,
+                "acceptances_count": 23,
+                "lines_suggested": 246,
+                "lines_accepted": 75,
+                "active_users": 3
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 52,
+                "acceptances_count": 15,
+                "lines_suggested": 64,
+                "lines_accepted": 15,
+                "active_users": 4
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 26,
+                "acceptances_count": 7,
+                "lines_suggested": 40,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 18,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 82,
+                "acceptances_count": 21,
+                "lines_suggested": 190,
+                "lines_accepted": 55,
+                "active_users": 7
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 2,
+                "lines_suggested": 44,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "toml",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 0,
+                "lines_suggested": 215,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 387,
+                "acceptances_count": 108,
+                "lines_suggested": 605,
+                "lines_accepted": 182,
+                "active_users": 10
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 19,
+                "acceptances_count": 4,
+                "lines_suggested": 34,
+                "lines_accepted": 14,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 0,
+                "lines_suggested": 20,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 2,
+                "lines_suggested": 8,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 5,
+                "lines_suggested": 49,
+                "lines_accepted": 27,
+                "active_users": 2
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 8,
+                "lines_suggested": 30,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 13,
+                "acceptances_count": 5,
+                "lines_suggested": 13,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 129,
+                "acceptances_count": 85,
+                "lines_suggested": 247,
+                "lines_accepted": 133,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "visual_studio",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 37,
+                "acceptances_count": 7,
+                "lines_suggested": 57,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 38,
+                "acceptances_count": 4,
+                "lines_suggested": 102,
+                "lines_accepted": 7,
+                "active_users": 3
+            },
+            {
+                "language": "go",
+                "editor": "jetbrains",
+                "suggestions_count": 7,
+                "acceptances_count": 3,
+                "lines_suggested": 27,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 34,
+                "acceptances_count": 10,
+                "lines_suggested": 106,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "jetbrains",
+                "suggestions_count": 15,
+                "acceptances_count": 2,
+                "lines_suggested": 29,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 33,
+                "acceptances_count": 22,
+                "lines_suggested": 70,
+                "lines_accepted": 50,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "vim",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "zsh",
+                "editor": "neovim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 20,
+                "acceptances_count": 9,
+                "lines_suggested": 49,
+                "lines_accepted": 9,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 11,
+        "total_chat_turns": 37,
+        "total_active_chat_users": 90
+    },
+    {
+        "day": "2024-04-03",
+        "total_suggestions_count": 8943,
+        "total_acceptances_count": 2240,
+        "total_lines_suggested": 19976,
+        "total_lines_accepted": 4386,
+        "total_active_users": 101,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 38,
+                "acceptances_count": 0,
+                "lines_suggested": 47,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 196,
+                "acceptances_count": 53,
+                "lines_suggested": 346,
+                "lines_accepted": 95,
+                "active_users": 11
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "puppet",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 3,
+                "lines_suggested": 24,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ssh_config",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1190,
+                "acceptances_count": 252,
+                "lines_suggested": 1817,
+                "lines_accepted": 351,
+                "active_users": 11
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 143,
+                "acceptances_count": 58,
+                "lines_suggested": 183,
+                "lines_accepted": 70,
+                "active_users": 5
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 755,
+                "acceptances_count": 240,
+                "lines_suggested": 1589,
+                "lines_accepted": 484,
+                "active_users": 21
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 290,
+                "acceptances_count": 63,
+                "lines_suggested": 405,
+                "lines_accepted": 133,
+                "active_users": 10
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 442,
+                "acceptances_count": 191,
+                "lines_suggested": 733,
+                "lines_accepted": 351,
+                "active_users": 13
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 6,
+                "lines_suggested": 11,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 263,
+                "acceptances_count": 145,
+                "lines_suggested": 1006,
+                "lines_accepted": 408,
+                "active_users": 10
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 640,
+                "acceptances_count": 144,
+                "lines_suggested": 1085,
+                "lines_accepted": 231,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 176,
+                "acceptances_count": 89,
+                "lines_suggested": 469,
+                "lines_accepted": 182,
+                "active_users": 5
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 196,
+                "acceptances_count": 41,
+                "lines_suggested": 373,
+                "lines_accepted": 97,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1171,
+                "acceptances_count": 344,
+                "lines_suggested": 2123,
+                "lines_accepted": 692,
+                "active_users": 14
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 37,
+                "acceptances_count": 7,
+                "lines_suggested": 92,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1260,
+                "acceptances_count": 192,
+                "lines_suggested": 1545,
+                "lines_accepted": 204,
+                "active_users": 17
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 12,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "swift",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 60,
+                "acceptances_count": 10,
+                "lines_suggested": 124,
+                "lines_accepted": 43,
+                "active_users": 5
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 281,
+                "acceptances_count": 40,
+                "lines_suggested": 1231,
+                "lines_accepted": 124,
+                "active_users": 2
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 15,
+                "lines_suggested": 17,
+                "lines_accepted": 15,
+                "active_users": 3
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 30,
+                "acceptances_count": 6,
+                "lines_suggested": 38,
+                "lines_accepted": 6,
+                "active_users": 4
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 79,
+                "acceptances_count": 6,
+                "lines_suggested": 198,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 120,
+                "acceptances_count": 12,
+                "lines_suggested": 242,
+                "lines_accepted": 19,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 188,
+                "acceptances_count": 38,
+                "lines_suggested": 274,
+                "lines_accepted": 63,
+                "active_users": 8
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 2,
+                "lines_suggested": 101,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 6,
+                "lines_suggested": 18,
+                "lines_accepted": 6,
+                "active_users": 5
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 1,
+                "lines_suggested": 22,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 69,
+                "acceptances_count": 33,
+                "lines_suggested": 333,
+                "lines_accepted": 255,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 67,
+                "acceptances_count": 20,
+                "lines_suggested": 147,
+                "lines_accepted": 23,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 54,
+                "acceptances_count": 16,
+                "lines_suggested": 123,
+                "lines_accepted": 61,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 27,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "perl",
+                "editor": "jetbrains",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 328,
+                "acceptances_count": 69,
+                "lines_suggested": 803,
+                "lines_accepted": 116,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 31,
+                "acceptances_count": 7,
+                "lines_suggested": 112,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 121,
+                "acceptances_count": 12,
+                "lines_suggested": 170,
+                "lines_accepted": 17,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 494,
+                "acceptances_count": 101,
+                "lines_suggested": 3844,
+                "lines_accepted": 258,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 42,
+                "acceptances_count": 12,
+                "lines_suggested": 145,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 35,
+                "acceptances_count": 0,
+                "lines_suggested": 94,
+                "lines_accepted": 0,
+                "active_users": 1
+            }
+        ],
+        "total_chat_acceptances": 11,
+        "total_chat_turns": 160,
+        "total_active_chat_users": 131
+    },
+    {
+        "day": "2024-04-04",
+        "total_suggestions_count": 12821,
+        "total_acceptances_count": 3067,
+        "total_lines_suggested": 27008,
+        "total_lines_accepted": 5982,
+        "total_active_users": 118,
+        "breakdown": [
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 80,
+                "acceptances_count": 2,
+                "lines_suggested": 95,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 222,
+                "acceptances_count": 52,
+                "lines_suggested": 365,
+                "lines_accepted": 105,
+                "active_users": 10
+            },
+            {
+                "language": "html.erb",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 6,
+                "lines_suggested": 38,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "puppet",
+                "editor": "vscode",
+                "suggestions_count": 19,
+                "acceptances_count": 4,
+                "lines_suggested": 77,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 73,
+                "acceptances_count": 11,
+                "lines_suggested": 172,
+                "lines_accepted": 24,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 1009,
+                "acceptances_count": 338,
+                "lines_suggested": 1573,
+                "lines_accepted": 510,
+                "active_users": 8
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 158,
+                "acceptances_count": 36,
+                "lines_suggested": 231,
+                "lines_accepted": 52,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 834,
+                "acceptances_count": 292,
+                "lines_suggested": 1853,
+                "lines_accepted": 836,
+                "active_users": 26
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 370,
+                "acceptances_count": 88,
+                "lines_suggested": 458,
+                "lines_accepted": 93,
+                "active_users": 10
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 1034,
+                "acceptances_count": 394,
+                "lines_suggested": 1498,
+                "lines_accepted": 609,
+                "active_users": 17
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 160,
+                "acceptances_count": 81,
+                "lines_suggested": 1433,
+                "lines_accepted": 517,
+                "active_users": 9
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 2,
+                "lines_suggested": 33,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 389,
+                "acceptances_count": 83,
+                "lines_suggested": 714,
+                "lines_accepted": 137,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 121,
+                "acceptances_count": 34,
+                "lines_suggested": 356,
+                "lines_accepted": 94,
+                "active_users": 5
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 99,
+                "acceptances_count": 16,
+                "lines_suggested": 404,
+                "lines_accepted": 36,
+                "active_users": 3
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 162,
+                "acceptances_count": 28,
+                "lines_suggested": 212,
+                "lines_accepted": 33,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 2424,
+                "acceptances_count": 613,
+                "lines_suggested": 4391,
+                "lines_accepted": 1119,
+                "active_users": 17
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 58,
+                "acceptances_count": 6,
+                "lines_suggested": 117,
+                "lines_accepted": 14,
+                "active_users": 4
+            },
+            {
+                "language": "cobol",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 3,
+                "lines_suggested": 8,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2432,
+                "acceptances_count": 247,
+                "lines_suggested": 3239,
+                "lines_accepted": 313,
+                "active_users": 19
+            },
+            {
+                "language": "tex",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 7,
+                "lines_suggested": 50,
+                "lines_accepted": 24,
+                "active_users": 4
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 51,
+                "acceptances_count": 13,
+                "lines_suggested": 224,
+                "lines_accepted": 53,
+                "active_users": 6
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 167,
+                "acceptances_count": 39,
+                "lines_suggested": 371,
+                "lines_accepted": 68,
+                "active_users": 5
+            },
+            {
+                "language": "vue",
+                "editor": "vscode",
+                "suggestions_count": 90,
+                "acceptances_count": 14,
+                "lines_suggested": 241,
+                "lines_accepted": 34,
+                "active_users": 2
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 38,
+                "acceptances_count": 22,
+                "lines_suggested": 46,
+                "lines_accepted": 24,
+                "active_users": 3
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 110,
+                "acceptances_count": 39,
+                "lines_suggested": 174,
+                "lines_accepted": 46,
+                "active_users": 4
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 53,
+                "acceptances_count": 2,
+                "lines_suggested": 119,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 134,
+                "acceptances_count": 18,
+                "lines_suggested": 353,
+                "lines_accepted": 18,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 314,
+                "acceptances_count": 90,
+                "lines_suggested": 552,
+                "lines_accepted": 150,
+                "active_users": 9
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 31,
+                "acceptances_count": 0,
+                "lines_suggested": 46,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 4,
+                "lines_suggested": 10,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 5,
+                "lines_suggested": 18,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 65,
+                "acceptances_count": 4,
+                "lines_suggested": 84,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 26,
+                "acceptances_count": 11,
+                "lines_suggested": 28,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "vs-markdown",
+                "editor": "visual_studio",
+                "suggestions_count": 57,
+                "acceptances_count": 17,
+                "lines_suggested": 57,
+                "lines_accepted": 17,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 29,
+                "acceptances_count": 12,
+                "lines_suggested": 55,
+                "lines_accepted": 34,
+                "active_users": 5
+            },
+            {
+                "language": "sql",
+                "editor": "visual_studio",
+                "suggestions_count": 7,
+                "acceptances_count": 5,
+                "lines_suggested": 8,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "msbuild",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "jetbrains",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 16,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 361,
+                "acceptances_count": 74,
+                "lines_suggested": 550,
+                "lines_accepted": 84,
+                "active_users": 3
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 12,
+                "acceptances_count": 4,
+                "lines_suggested": 22,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 2,
+                "lines_suggested": 33,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "jetbrains",
+                "suggestions_count": 142,
+                "acceptances_count": 61,
+                "lines_suggested": 177,
+                "lines_accepted": 73,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 27,
+                "acceptances_count": 12,
+                "lines_suggested": 92,
+                "lines_accepted": 72,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "jetbrains",
+                "suggestions_count": 26,
+                "acceptances_count": 4,
+                "lines_suggested": 27,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "sql",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 3,
+                "lines_suggested": 7,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "conf",
+                "editor": "vim",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 1208,
+                "acceptances_count": 260,
+                "lines_suggested": 6096,
+                "lines_accepted": 687,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 39,
+                "acceptances_count": 9,
+                "lines_suggested": 197,
+                "lines_accepted": 20,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 14,
+                "acceptances_count": 0,
+                "lines_suggested": 32,
+                "lines_accepted": 0,
+                "active_users": 1
+            }
+        ],
+        "total_chat_acceptances": 15,
+        "total_chat_turns": 16,
+        "total_active_chat_users": 45
+    },
+    {
+        "day": "2024-04-06",
+        "total_suggestions_count": 5345,
+        "total_acceptances_count": 1476,
+        "total_lines_suggested": 10927,
+        "total_lines_accepted": 2433,
+        "total_active_users": 32,
+        "breakdown": [
+            {
+                "language": "aspnetcorerazor",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 0,
+                "lines_suggested": 16,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "jade",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 0,
+                "lines_suggested": 18,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 253,
+                "acceptances_count": 69,
+                "lines_suggested": 401,
+                "lines_accepted": 100,
+                "active_users": 5
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 2,
+                "lines_suggested": 17,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 362,
+                "acceptances_count": 120,
+                "lines_suggested": 621,
+                "lines_accepted": 213,
+                "active_users": 8
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 743,
+                "acceptances_count": 330,
+                "lines_suggested": 1162,
+                "lines_accepted": 590,
+                "active_users": 9
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 93,
+                "acceptances_count": 52,
+                "lines_suggested": 272,
+                "lines_accepted": 137,
+                "active_users": 2
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 8,
+                "lines_suggested": 160,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 112,
+                "acceptances_count": 42,
+                "lines_suggested": 151,
+                "lines_accepted": 50,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 47,
+                "acceptances_count": 15,
+                "lines_suggested": 68,
+                "lines_accepted": 26,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 664,
+                "acceptances_count": 192,
+                "lines_suggested": 1062,
+                "lines_accepted": 340,
+                "active_users": 7
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 89,
+                "acceptances_count": 10,
+                "lines_suggested": 179,
+                "lines_accepted": 23,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1997,
+                "acceptances_count": 431,
+                "lines_suggested": 3031,
+                "lines_accepted": 479,
+                "active_users": 5
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 10,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "nix",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 1,
+                "lines_suggested": 28,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 2,
+                "lines_suggested": 92,
+                "lines_accepted": 8,
+                "active_users": 3
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 13,
+                "acceptances_count": 2,
+                "lines_suggested": 16,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 276,
+                "acceptances_count": 55,
+                "lines_suggested": 579,
+                "lines_accepted": 86,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 5,
+                "lines_suggested": 28,
+                "lines_accepted": 15,
+                "active_users": 3
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 37,
+                "acceptances_count": 10,
+                "lines_suggested": 62,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 56,
+                "acceptances_count": 21,
+                "lines_suggested": 97,
+                "lines_accepted": 40,
+                "active_users": 3
+            },
+            {
+                "language": "json",
+                "editor": "visual_studio",
+                "suggestions_count": 8,
+                "acceptances_count": 3,
+                "lines_suggested": 8,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 17,
+                "acceptances_count": 1,
+                "lines_suggested": 37,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 62,
+                "acceptances_count": 8,
+                "lines_suggested": 113,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "sshconfig",
+                "editor": "vim",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 30,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 245,
+                "acceptances_count": 64,
+                "lines_suggested": 1624,
+                "lines_accepted": 161,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 62,
+                "acceptances_count": 31,
+                "lines_suggested": 1001,
+                "lines_accepted": 105,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 102,
+        "total_chat_turns": 22,
+        "total_active_chat_users": 115
+    },
+    {
+        "day": "2024-04-07",
+        "total_suggestions_count": 6539,
+        "total_acceptances_count": 1901,
+        "total_lines_suggested": 13533,
+        "total_lines_accepted": 3611,
+        "total_active_users": 38,
+        "breakdown": [
+            {
+                "language": "fsharp",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 34,
+                "lines_suggested": 199,
+                "lines_accepted": 61,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 1,
+                "lines_suggested": 10,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 5,
+                "lines_suggested": 31,
+                "lines_accepted": 21,
+                "active_users": 2
+            },
+            {
+                "language": "jade",
+                "editor": "vscode",
+                "suggestions_count": 135,
+                "acceptances_count": 56,
+                "lines_suggested": 235,
+                "lines_accepted": 103,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 31,
+                "acceptances_count": 0,
+                "lines_suggested": 80,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "rmd",
+                "editor": "vscode",
+                "suggestions_count": 38,
+                "acceptances_count": 1,
+                "lines_suggested": 44,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 675,
+                "acceptances_count": 196,
+                "lines_suggested": 1127,
+                "lines_accepted": 343,
+                "active_users": 9
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 397,
+                "acceptances_count": 122,
+                "lines_suggested": 599,
+                "lines_accepted": 212,
+                "active_users": 5
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 1173,
+                "acceptances_count": 410,
+                "lines_suggested": 1907,
+                "lines_accepted": 712,
+                "active_users": 6
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 110,
+                "acceptances_count": 24,
+                "lines_suggested": 431,
+                "lines_accepted": 151,
+                "active_users": 3
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 14,
+                "acceptances_count": 10,
+                "lines_suggested": 14,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 57,
+                "acceptances_count": 1,
+                "lines_suggested": 157,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 36,
+                "acceptances_count": 8,
+                "lines_suggested": 43,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 188,
+                "acceptances_count": 76,
+                "lines_suggested": 450,
+                "lines_accepted": 112,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 25,
+                "acceptances_count": 9,
+                "lines_suggested": 75,
+                "lines_accepted": 31,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 411,
+                "acceptances_count": 129,
+                "lines_suggested": 1053,
+                "lines_accepted": 393,
+                "active_users": 6
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 76,
+                "acceptances_count": 12,
+                "lines_suggested": 191,
+                "lines_accepted": 25,
+                "active_users": 5
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1697,
+                "acceptances_count": 373,
+                "lines_suggested": 2804,
+                "lines_accepted": 453,
+                "active_users": 5
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 39,
+                "acceptances_count": 19,
+                "lines_suggested": 42,
+                "lines_accepted": 19,
+                "active_users": 3
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 26,
+                "acceptances_count": 0,
+                "lines_suggested": 29,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 90,
+                "acceptances_count": 16,
+                "lines_suggested": 149,
+                "lines_accepted": 28,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 146,
+                "acceptances_count": 17,
+                "lines_suggested": 212,
+                "lines_accepted": 17,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 53,
+                "acceptances_count": 16,
+                "lines_suggested": 174,
+                "lines_accepted": 31,
+                "active_users": 3
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 77,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 4,
+                "lines_suggested": 30,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 67,
+                "acceptances_count": 21,
+                "lines_suggested": 195,
+                "lines_accepted": 73,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "visual_studio",
+                "suggestions_count": 41,
+                "acceptances_count": 8,
+                "lines_suggested": 132,
+                "lines_accepted": 17,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "visual_studio",
+                "suggestions_count": 104,
+                "acceptances_count": 26,
+                "lines_suggested": 125,
+                "lines_accepted": 39,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 97,
+                "acceptances_count": 30,
+                "lines_suggested": 160,
+                "lines_accepted": 52,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 34,
+                "acceptances_count": 12,
+                "lines_suggested": 54,
+                "lines_accepted": 26,
+                "active_users": 2
+            },
+            {
+                "language": "plm",
+                "editor": "vim",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sshconfig",
+                "editor": "vim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 15,
+                "acceptances_count": 2,
+                "lines_suggested": 29,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 278,
+                "acceptances_count": 79,
+                "lines_suggested": 1108,
+                "lines_accepted": 207,
+                "active_users": 2
+            },
+            {
+                "language": "css",
+                "editor": "neovim",
+                "suggestions_count": 27,
+                "acceptances_count": 4,
+                "lines_suggested": 144,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "neovim",
+                "suggestions_count": 318,
+                "acceptances_count": 179,
+                "lines_suggested": 1407,
+                "lines_accepted": 448,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 194,
+        "total_chat_turns": 140,
+        "total_active_chat_users": 58
+    },
+    {
+        "day": "2024-04-08",
+        "total_suggestions_count": 8587,
+        "total_acceptances_count": 2380,
+        "total_lines_suggested": 16254,
+        "total_lines_accepted": 4618,
+        "total_active_users": 96,
+        "breakdown": [
+            {
+                "language": "django-html",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 11,
+                "lines_accepted": 9,
+                "active_users": 2
+            },
+            {
+                "language": "django-txt",
+                "editor": "vscode",
+                "suggestions_count": 20,
+                "acceptances_count": 10,
+                "lines_suggested": 24,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "dockercompose",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 2,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 27,
+                "acceptances_count": 2,
+                "lines_suggested": 30,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 516,
+                "acceptances_count": 195,
+                "lines_suggested": 1084,
+                "lines_accepted": 370,
+                "active_users": 8
+            },
+            {
+                "language": "helm",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "html.erb",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 10,
+                "lines_suggested": 132,
+                "lines_accepted": 34,
+                "active_users": 2
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 18,
+                "lines_suggested": 38,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 8,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 1,
+                "lines_suggested": 31,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 525,
+                "acceptances_count": 130,
+                "lines_suggested": 817,
+                "lines_accepted": 174,
+                "active_users": 12
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 21,
+                "lines_suggested": 112,
+                "lines_accepted": 42,
+                "active_users": 4
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 628,
+                "acceptances_count": 200,
+                "lines_suggested": 1330,
+                "lines_accepted": 521,
+                "active_users": 15
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 308,
+                "acceptances_count": 106,
+                "lines_suggested": 447,
+                "lines_accepted": 114,
+                "active_users": 8
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 908,
+                "acceptances_count": 343,
+                "lines_suggested": 1355,
+                "lines_accepted": 536,
+                "active_users": 14
+            },
+            {
+                "language": "perl",
+                "editor": "vscode",
+                "suggestions_count": 13,
+                "acceptances_count": 1,
+                "lines_suggested": 15,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 207,
+                "acceptances_count": 104,
+                "lines_suggested": 403,
+                "lines_accepted": 257,
+                "active_users": 10
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 37,
+                "acceptances_count": 14,
+                "lines_suggested": 63,
+                "lines_accepted": 22,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 103,
+                "acceptances_count": 25,
+                "lines_suggested": 422,
+                "lines_accepted": 40,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 30,
+                "lines_suggested": 260,
+                "lines_accepted": 153,
+                "active_users": 4
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 24,
+                "acceptances_count": 3,
+                "lines_suggested": 59,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 0,
+                "lines_suggested": 24,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 5,
+                "lines_suggested": 47,
+                "lines_accepted": 27,
+                "active_users": 3
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1525,
+                "acceptances_count": 413,
+                "lines_suggested": 2486,
+                "lines_accepted": 808,
+                "active_users": 19
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 36,
+                "acceptances_count": 16,
+                "lines_suggested": 71,
+                "lines_accepted": 36,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1642,
+                "acceptances_count": 319,
+                "lines_suggested": 2140,
+                "lines_accepted": 367,
+                "active_users": 14
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 5,
+                "lines_suggested": 58,
+                "lines_accepted": 22,
+                "active_users": 3
+            },
+            {
+                "language": "makefile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 60,
+                "acceptances_count": 20,
+                "lines_suggested": 152,
+                "lines_accepted": 47,
+                "active_users": 4
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 134,
+                "acceptances_count": 58,
+                "lines_suggested": 682,
+                "lines_accepted": 331,
+                "active_users": 3
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 23,
+                "acceptances_count": 19,
+                "lines_suggested": 25,
+                "lines_accepted": 20,
+                "active_users": 2
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 14,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 10,
+                "lines_suggested": 80,
+                "lines_accepted": 10,
+                "active_users": 7
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 43,
+                "acceptances_count": 3,
+                "lines_suggested": 88,
+                "lines_accepted": 5,
+                "active_users": 3
+            },
+            {
+                "language": "toml",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 208,
+                "acceptances_count": 20,
+                "lines_suggested": 294,
+                "lines_accepted": 27,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 407,
+                "acceptances_count": 107,
+                "lines_suggested": 1013,
+                "lines_accepted": 272,
+                "active_users": 14
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 53,
+                "acceptances_count": 6,
+                "lines_suggested": 80,
+                "lines_accepted": 6,
+                "active_users": 4
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 2,
+                "lines_suggested": 18,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 6,
+                "lines_suggested": 19,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 86,
+                "acceptances_count": 8,
+                "lines_suggested": 98,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 39,
+                "acceptances_count": 12,
+                "lines_suggested": 48,
+                "lines_accepted": 14,
+                "active_users": 2
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 34,
+                "acceptances_count": 8,
+                "lines_suggested": 89,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "properties",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 63,
+                "acceptances_count": 15,
+                "lines_suggested": 89,
+                "lines_accepted": 23,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 18,
+                "acceptances_count": 3,
+                "lines_suggested": 23,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 14,
+                "acceptances_count": 11,
+                "lines_suggested": 38,
+                "lines_accepted": 33,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 9,
+                "acceptances_count": 2,
+                "lines_suggested": 15,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 16,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "jetbrains",
+                "suggestions_count": 10,
+                "acceptances_count": 1,
+                "lines_suggested": 29,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 32,
+                "acceptances_count": 4,
+                "lines_suggested": 45,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 3,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 343,
+                "acceptances_count": 71,
+                "lines_suggested": 1603,
+                "lines_accepted": 113,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 18,
+                "acceptances_count": 3,
+                "lines_suggested": 48,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "emacs-lisp",
+                "editor": "emacs",
+                "suggestions_count": 10,
+                "acceptances_count": 2,
+                "lines_suggested": 13,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "rjsx",
+                "editor": "emacs",
+                "suggestions_count": 30,
+                "acceptances_count": 9,
+                "lines_suggested": 107,
+                "lines_accepted": 62,
+                "active_users": 2
+            },
+            {
+                "language": "graphql",
+                "editor": "emacs",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 28,
+                "lines_accepted": 0,
+                "active_users": 1
+            }
+        ],
+        "total_chat_acceptances": 125,
+        "total_chat_turns": 178,
+        "total_active_chat_users": 199
+    },
+    {
+        "day": "2024-04-09",
+        "total_suggestions_count": 10008,
+        "total_acceptances_count": 2391,
+        "total_lines_suggested": 18542,
+        "total_lines_accepted": 4514,
+        "total_active_users": 112,
+        "breakdown": [
+            {
+                "language": "gemfile",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 21,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 510,
+                "acceptances_count": 182,
+                "lines_suggested": 1214,
+                "lines_accepted": 457,
+                "active_users": 9
+            },
+            {
+                "language": "html.erb",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 6,
+                "lines_suggested": 44,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "objective-cpp",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 16,
+                "acceptances_count": 1,
+                "lines_suggested": 18,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "properties",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 10,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "restructuredtext",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 28,
+                "acceptances_count": 4,
+                "lines_suggested": 108,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 601,
+                "acceptances_count": 103,
+                "lines_suggested": 900,
+                "lines_accepted": 126,
+                "active_users": 11
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 511,
+                "acceptances_count": 189,
+                "lines_suggested": 809,
+                "lines_accepted": 316,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 471,
+                "acceptances_count": 156,
+                "lines_suggested": 1025,
+                "lines_accepted": 310,
+                "active_users": 22
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 561,
+                "acceptances_count": 174,
+                "lines_suggested": 787,
+                "lines_accepted": 188,
+                "active_users": 11
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 559,
+                "acceptances_count": 189,
+                "lines_suggested": 1005,
+                "lines_accepted": 435,
+                "active_users": 19
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 93,
+                "acceptances_count": 53,
+                "lines_suggested": 912,
+                "lines_accepted": 352,
+                "active_users": 9
+            },
+            {
+                "language": "groovy",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 51,
+                "acceptances_count": 8,
+                "lines_suggested": 73,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 302,
+                "acceptances_count": 68,
+                "lines_suggested": 522,
+                "lines_accepted": 84,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 26,
+                "lines_suggested": 211,
+                "lines_accepted": 180,
+                "active_users": 3
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 2,
+                "lines_suggested": 5,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1267,
+                "acceptances_count": 375,
+                "lines_suggested": 2019,
+                "lines_accepted": 620,
+                "active_users": 15
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 39,
+                "acceptances_count": 9,
+                "lines_suggested": 62,
+                "lines_accepted": 15,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2577,
+                "acceptances_count": 375,
+                "lines_suggested": 3681,
+                "lines_accepted": 417,
+                "active_users": 17
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 17,
+                "acceptances_count": 1,
+                "lines_suggested": 24,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 74,
+                "acceptances_count": 38,
+                "lines_suggested": 81,
+                "lines_accepted": 42,
+                "active_users": 4
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 9,
+                "acceptances_count": 1,
+                "lines_suggested": 15,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 136,
+                "acceptances_count": 24,
+                "lines_suggested": 414,
+                "lines_accepted": 148,
+                "active_users": 11
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 438,
+                "acceptances_count": 16,
+                "lines_suggested": 600,
+                "lines_accepted": 22,
+                "active_users": 3
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 395,
+                "acceptances_count": 79,
+                "lines_suggested": 631,
+                "lines_accepted": 143,
+                "active_users": 13
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 41,
+                "acceptances_count": 19,
+                "lines_suggested": 51,
+                "lines_accepted": 19,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "bicep",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "astro",
+                "editor": "vscode",
+                "suggestions_count": 57,
+                "acceptances_count": 20,
+                "lines_suggested": 312,
+                "lines_accepted": 99,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 33,
+                "acceptances_count": 3,
+                "lines_suggested": 37,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 26,
+                "acceptances_count": 7,
+                "lines_suggested": 61,
+                "lines_accepted": 11,
+                "active_users": 2
+            },
+            {
+                "language": "vs-markdown",
+                "editor": "visual_studio",
+                "suggestions_count": 7,
+                "acceptances_count": 0,
+                "lines_suggested": 7,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 42,
+                "acceptances_count": 20,
+                "lines_suggested": 94,
+                "lines_accepted": 66,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "visual_studio",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "visual_studio",
+                "suggestions_count": 18,
+                "acceptances_count": 13,
+                "lines_suggested": 18,
+                "lines_accepted": 13,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "visual_studio",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 80,
+                "acceptances_count": 5,
+                "lines_suggested": 194,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 69,
+                "acceptances_count": 10,
+                "lines_suggested": 128,
+                "lines_accepted": 13,
+                "active_users": 3
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 44,
+                "acceptances_count": 18,
+                "lines_suggested": 55,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 124,
+                "acceptances_count": 41,
+                "lines_suggested": 285,
+                "lines_accepted": 75,
+                "active_users": 4
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 25,
+                "acceptances_count": 10,
+                "lines_suggested": 105,
+                "lines_accepted": 20,
+                "active_users": 2
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 16,
+                "acceptances_count": 3,
+                "lines_suggested": 40,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 36,
+                "acceptances_count": 9,
+                "lines_suggested": 53,
+                "lines_accepted": 13,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sshconfig",
+                "editor": "vim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 20,
+                "acceptances_count": 3,
+                "lines_suggested": 134,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "eruby",
+                "editor": "neovim",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 4,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "neovim",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "neovim",
+                "suggestions_count": 383,
+                "acceptances_count": 79,
+                "lines_suggested": 1185,
+                "lines_accepted": 151,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "neovim",
+                "suggestions_count": 3,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 6,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 53,
+                "acceptances_count": 6,
+                "lines_suggested": 190,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "neovim",
+                "suggestions_count": 43,
+                "acceptances_count": 10,
+                "lines_suggested": 108,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "neovim",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 48,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "emacs-lisp",
+                "editor": "emacs",
+                "suggestions_count": 79,
+                "acceptances_count": 29,
+                "lines_suggested": 171,
+                "lines_accepted": 85,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 134,
+        "total_chat_turns": 146,
+        "total_active_chat_users": 136
+    },
+    {
+        "day": "2024-04-10",
+        "total_suggestions_count": 10301,
+        "total_acceptances_count": 2600,
+        "total_lines_suggested": 18825,
+        "total_lines_accepted": 4752,
+        "total_active_users": 125,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 15,
+                "acceptances_count": 0,
+                "lines_suggested": 20,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 377,
+                "acceptances_count": 139,
+                "lines_suggested": 537,
+                "lines_accepted": 189,
+                "active_users": 4
+            },
+            {
+                "language": "html.erb",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 2,
+                "lines_suggested": 30,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "vscode",
+                "suggestions_count": 54,
+                "acceptances_count": 39,
+                "lines_suggested": 156,
+                "lines_accepted": 60,
+                "active_users": 2
+            },
+            {
+                "language": "kusto",
+                "editor": "vscode",
+                "suggestions_count": 21,
+                "acceptances_count": 2,
+                "lines_suggested": 29,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "nunjucks",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 0,
+                "lines_suggested": 21,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "terraform-vars",
+                "editor": "vscode",
+                "suggestions_count": 37,
+                "acceptances_count": 23,
+                "lines_suggested": 41,
+                "lines_accepted": 23,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 573,
+                "acceptances_count": 164,
+                "lines_suggested": 833,
+                "lines_accepted": 230,
+                "active_users": 9
+            },
+            {
+                "language": "unknown",
+                "editor": "vscode",
+                "suggestions_count": 161,
+                "acceptances_count": 66,
+                "lines_suggested": 302,
+                "lines_accepted": 66,
+                "active_users": 5
+            },
+            {
+                "language": "vb",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 1,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 324,
+                "acceptances_count": 96,
+                "lines_suggested": 486,
+                "lines_accepted": 139,
+                "active_users": 8
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 1388,
+                "acceptances_count": 349,
+                "lines_suggested": 2723,
+                "lines_accepted": 978,
+                "active_users": 24
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 737,
+                "acceptances_count": 259,
+                "lines_suggested": 2016,
+                "lines_accepted": 426,
+                "active_users": 16
+            },
+            {
+                "language": "c++",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 1546,
+                "acceptances_count": 430,
+                "lines_suggested": 2786,
+                "lines_accepted": 830,
+                "active_users": 22
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 223,
+                "acceptances_count": 119,
+                "lines_suggested": 670,
+                "lines_accepted": 347,
+                "active_users": 14
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 181,
+                "acceptances_count": 48,
+                "lines_suggested": 236,
+                "lines_accepted": 57,
+                "active_users": 8
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 46,
+                "acceptances_count": 26,
+                "lines_suggested": 146,
+                "lines_accepted": 103,
+                "active_users": 4
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 34,
+                "acceptances_count": 7,
+                "lines_suggested": 106,
+                "lines_accepted": 28,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 5,
+                "lines_suggested": 25,
+                "lines_accepted": 13,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1472,
+                "acceptances_count": 316,
+                "lines_suggested": 2438,
+                "lines_accepted": 559,
+                "active_users": 12
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 99,
+                "acceptances_count": 19,
+                "lines_suggested": 229,
+                "lines_accepted": 47,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1643,
+                "acceptances_count": 208,
+                "lines_suggested": 2231,
+                "lines_accepted": 236,
+                "active_users": 24
+            },
+            {
+                "language": "tex",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 19,
+                "acceptances_count": 10,
+                "lines_suggested": 58,
+                "lines_accepted": 25,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 112,
+                "acceptances_count": 25,
+                "lines_suggested": 245,
+                "lines_accepted": 49,
+                "active_users": 10
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 85,
+                "acceptances_count": 14,
+                "lines_suggested": 120,
+                "lines_accepted": 26,
+                "active_users": 3
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html+erb",
+                "editor": "vscode",
+                "suggestions_count": 32,
+                "acceptances_count": 2,
+                "lines_suggested": 55,
+                "lines_accepted": 2,
+                "active_users": 3
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 79,
+                "acceptances_count": 8,
+                "lines_suggested": 88,
+                "lines_accepted": 11,
+                "active_users": 7
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 40,
+                "acceptances_count": 1,
+                "lines_suggested": 140,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 69,
+                "acceptances_count": 5,
+                "lines_suggested": 154,
+                "lines_accepted": 5,
+                "active_users": 5
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 293,
+                "acceptances_count": 82,
+                "lines_suggested": 396,
+                "lines_accepted": 108,
+                "active_users": 13
+            },
+            {
+                "language": "postcss",
+                "editor": "vscode",
+                "suggestions_count": 76,
+                "acceptances_count": 23,
+                "lines_suggested": 209,
+                "lines_accepted": 31,
+                "active_users": 2
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 72,
+                "acceptances_count": 4,
+                "lines_suggested": 100,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 22,
+                "acceptances_count": 3,
+                "lines_suggested": 33,
+                "lines_accepted": 3,
+                "active_users": 3
+            },
+            {
+                "language": "prisma",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "mdx",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 31,
+                "acceptances_count": 2,
+                "lines_suggested": 59,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "javascriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 7,
+                "acceptances_count": 3,
+                "lines_suggested": 35,
+                "lines_accepted": 13,
+                "active_users": 2
+            },
+            {
+                "language": "razor",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 4,
+                "lines_suggested": 30,
+                "lines_accepted": 14,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 13,
+                "acceptances_count": 0,
+                "lines_suggested": 37,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "kotlin",
+                "editor": "jetbrains",
+                "suggestions_count": 52,
+                "acceptances_count": 13,
+                "lines_suggested": 87,
+                "lines_accepted": 18,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "markdown",
+                "editor": "jetbrains",
+                "suggestions_count": 11,
+                "acceptances_count": 0,
+                "lines_suggested": 14,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "vim",
+                "suggestions_count": 7,
+                "acceptances_count": 1,
+                "lines_suggested": 8,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "neovim",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 13,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascript",
+                "editor": "neovim",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 21,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 177,
+                "acceptances_count": 56,
+                "lines_suggested": 458,
+                "lines_accepted": 66,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 102,
+                "acceptances_count": 19,
+                "lines_suggested": 348,
+                "lines_accepted": 19,
+                "active_users": 2
+            },
+            {
+                "language": "emacs-lisp",
+                "editor": "emacs",
+                "suggestions_count": 10,
+                "acceptances_count": 5,
+                "lines_suggested": 34,
+                "lines_accepted": 16,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 55,
+        "total_chat_turns": 108,
+        "total_active_chat_users": 10
+    },
+    {
+        "day": "2024-04-11",
+        "total_suggestions_count": 11811,
+        "total_acceptances_count": 3194,
+        "total_lines_suggested": 20636,
+        "total_lines_accepted": 5512,
+        "total_active_users": 116,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 48,
+                "acceptances_count": 2,
+                "lines_suggested": 61,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "github-actions-workflow",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 2,
+                "lines_suggested": 10,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "pip-requirements",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 54,
+                "acceptances_count": 8,
+                "lines_suggested": 92,
+                "lines_accepted": 9,
+                "active_users": 3
+            },
+            {
+                "language": "scminput",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 889,
+                "acceptances_count": 240,
+                "lines_suggested": 1325,
+                "lines_accepted": 326,
+                "active_users": 16
+            },
+            {
+                "language": "unknown",
+                "editor": "vscode",
+                "suggestions_count": 397,
+                "acceptances_count": 113,
+                "lines_suggested": 923,
+                "lines_accepted": 174,
+                "active_users": 15
+            },
+            {
+                "language": "vb",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 2,
+                "lines_suggested": 7,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 255,
+                "acceptances_count": 95,
+                "lines_suggested": 349,
+                "lines_accepted": 100,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 1386,
+                "acceptances_count": 421,
+                "lines_suggested": 2418,
+                "lines_accepted": 817,
+                "active_users": 23
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 449,
+                "acceptances_count": 128,
+                "lines_suggested": 647,
+                "lines_accepted": 159,
+                "active_users": 10
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 740,
+                "acceptances_count": 313,
+                "lines_suggested": 1111,
+                "lines_accepted": 507,
+                "active_users": 16
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 245,
+                "acceptances_count": 115,
+                "lines_suggested": 1091,
+                "lines_accepted": 460,
+                "active_users": 10
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 1,
+                "lines_suggested": 7,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 584,
+                "acceptances_count": 172,
+                "lines_suggested": 1087,
+                "lines_accepted": 236,
+                "active_users": 6
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 39,
+                "lines_suggested": 269,
+                "lines_accepted": 200,
+                "active_users": 5
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 128,
+                "acceptances_count": 32,
+                "lines_suggested": 218,
+                "lines_accepted": 57,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 6,
+                "lines_suggested": 21,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "dart",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 8,
+                "acceptances_count": 0,
+                "lines_suggested": 9,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 2130,
+                "acceptances_count": 432,
+                "lines_suggested": 3175,
+                "lines_accepted": 734,
+                "active_users": 16
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 197,
+                "acceptances_count": 36,
+                "lines_suggested": 396,
+                "lines_accepted": 66,
+                "active_users": 8
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2040,
+                "acceptances_count": 337,
+                "lines_suggested": 2930,
+                "lines_accepted": 392,
+                "active_users": 16
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 57,
+                "acceptances_count": 36,
+                "lines_suggested": 98,
+                "lines_accepted": 73,
+                "active_users": 4
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 48,
+                "acceptances_count": 11,
+                "lines_suggested": 176,
+                "lines_accepted": 54,
+                "active_users": 6
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 87,
+                "acceptances_count": 18,
+                "lines_suggested": 251,
+                "lines_accepted": 58,
+                "active_users": 5
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 15,
+                "acceptances_count": 3,
+                "lines_suggested": 18,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 113,
+                "acceptances_count": 19,
+                "lines_suggested": 172,
+                "lines_accepted": 44,
+                "active_users": 9
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 225,
+                "acceptances_count": 19,
+                "lines_suggested": 242,
+                "lines_accepted": 19,
+                "active_users": 4
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 876,
+                "acceptances_count": 370,
+                "lines_suggested": 1688,
+                "lines_accepted": 566,
+                "active_users": 20
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 44,
+                "acceptances_count": 2,
+                "lines_suggested": 66,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "ignore list",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "c#",
+                "editor": "visual_studio",
+                "suggestions_count": 136,
+                "acceptances_count": 62,
+                "lines_suggested": 418,
+                "lines_accepted": 193,
+                "active_users": 3
+            },
+            {
+                "language": "blazor",
+                "editor": "jetbrains",
+                "suggestions_count": 19,
+                "acceptances_count": 2,
+                "lines_suggested": 105,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 125,
+                "acceptances_count": 52,
+                "lines_suggested": 260,
+                "lines_accepted": 88,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 1,
+                "lines_suggested": 4,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 42,
+                "acceptances_count": 10,
+                "lines_suggested": 49,
+                "lines_accepted": 12,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 7,
+                "acceptances_count": 3,
+                "lines_suggested": 7,
+                "lines_accepted": 3,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 81,
+                "acceptances_count": 18,
+                "lines_suggested": 247,
+                "lines_accepted": 26,
+                "active_users": 3
+            },
+            {
+                "language": "xml",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "jetbrains",
+                "suggestions_count": 9,
+                "acceptances_count": 7,
+                "lines_suggested": 9,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "html",
+                "editor": "jetbrains",
+                "suggestions_count": 1,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "neovim",
+                "suggestions_count": 89,
+                "acceptances_count": 26,
+                "lines_suggested": 196,
+                "lines_accepted": 36,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "neovim",
+                "suggestions_count": 30,
+                "acceptances_count": 5,
+                "lines_suggested": 70,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "ruby",
+                "editor": "neovim",
+                "suggestions_count": 22,
+                "acceptances_count": 2,
+                "lines_suggested": 68,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "neovim",
+                "suggestions_count": 8,
+                "acceptances_count": 5,
+                "lines_suggested": 11,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "markdown",
+                "editor": "neovim",
+                "suggestions_count": 30,
+                "acceptances_count": 1,
+                "lines_suggested": 115,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "toml",
+                "editor": "neovim",
+                "suggestions_count": 24,
+                "acceptances_count": 3,
+                "lines_suggested": 89,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "emacs-lisp",
+                "editor": "emacs",
+                "suggestions_count": 62,
+                "acceptances_count": 24,
+                "lines_suggested": 113,
+                "lines_accepted": 48,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 7,
+        "total_chat_turns": 43,
+        "total_active_chat_users": 99
+    },
+    {
+        "day": "2024-04-12",
+        "total_suggestions_count": 9105,
+        "total_acceptances_count": 2137,
+        "total_lines_suggested": 14478,
+        "total_lines_accepted": 3554,
+        "total_active_users": 105,
+        "breakdown": [
+            {
+                "language": "git-commit",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "ql",
+                "editor": "vscode",
+                "suggestions_count": 62,
+                "acceptances_count": 13,
+                "lines_suggested": 95,
+                "lines_accepted": 16,
+                "active_users": 3
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 606,
+                "acceptances_count": 95,
+                "lines_suggested": 942,
+                "lines_accepted": 163,
+                "active_users": 9
+            },
+            {
+                "language": "unknown",
+                "editor": "vscode",
+                "suggestions_count": 474,
+                "acceptances_count": 14,
+                "lines_suggested": 534,
+                "lines_accepted": 14,
+                "active_users": 7
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 61,
+                "acceptances_count": 25,
+                "lines_suggested": 85,
+                "lines_accepted": 28,
+                "active_users": 6
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 619,
+                "acceptances_count": 235,
+                "lines_suggested": 1295,
+                "lines_accepted": 540,
+                "active_users": 19
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 418,
+                "acceptances_count": 87,
+                "lines_suggested": 566,
+                "lines_accepted": 97,
+                "active_users": 13
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 702,
+                "acceptances_count": 225,
+                "lines_suggested": 942,
+                "lines_accepted": 299,
+                "active_users": 16
+            },
+            {
+                "language": "php",
+                "editor": "vscode",
+                "suggestions_count": 18,
+                "acceptances_count": 0,
+                "lines_suggested": 38,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "objective-c",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 3,
+                "lines_suggested": 31,
+                "lines_accepted": 15,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 50,
+                "acceptances_count": 24,
+                "lines_suggested": 100,
+                "lines_accepted": 45,
+                "active_users": 5
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 757,
+                "acceptances_count": 274,
+                "lines_suggested": 1608,
+                "lines_accepted": 512,
+                "active_users": 4
+            },
+            {
+                "language": "c#",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 2,
+                "lines_suggested": 7,
+                "lines_accepted": 4,
+                "active_users": 2
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 82,
+                "acceptances_count": 10,
+                "lines_suggested": 112,
+                "lines_accepted": 10,
+                "active_users": 2
+            },
+            {
+                "language": "powershell",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "kotlin",
+                "editor": "vscode",
+                "suggestions_count": 11,
+                "acceptances_count": 8,
+                "lines_suggested": 94,
+                "lines_accepted": 25,
+                "active_users": 2
+            },
+            {
+                "language": "xml",
+                "editor": "vscode",
+                "suggestions_count": 10,
+                "acceptances_count": 1,
+                "lines_suggested": 56,
+                "lines_accepted": 16,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 1341,
+                "acceptances_count": 378,
+                "lines_suggested": 1923,
+                "lines_accepted": 594,
+                "active_users": 12
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 107,
+                "acceptances_count": 30,
+                "lines_suggested": 156,
+                "lines_accepted": 37,
+                "active_users": 4
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 2182,
+                "acceptances_count": 391,
+                "lines_suggested": 3096,
+                "lines_accepted": 450,
+                "active_users": 26
+            },
+            {
+                "language": "tex",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 45,
+                "acceptances_count": 21,
+                "lines_suggested": 62,
+                "lines_accepted": 37,
+                "active_users": 3
+            },
+            {
+                "language": "makefile",
+                "editor": "vscode",
+                "suggestions_count": 5,
+                "acceptances_count": 0,
+                "lines_suggested": 5,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "html",
+                "editor": "vscode",
+                "suggestions_count": 72,
+                "acceptances_count": 21,
+                "lines_suggested": 165,
+                "lines_accepted": 31,
+                "active_users": 7
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 5,
+                "lines_suggested": 36,
+                "lines_accepted": 5,
+                "active_users": 3
+            },
+            {
+                "language": "ini",
+                "editor": "vscode",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 4,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 71,
+                "acceptances_count": 6,
+                "lines_suggested": 109,
+                "lines_accepted": 6,
+                "active_users": 3
+            },
+            {
+                "language": "scss",
+                "editor": "vscode",
+                "suggestions_count": 2,
+                "acceptances_count": 0,
+                "lines_suggested": 2,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 504,
+                "acceptances_count": 32,
+                "lines_suggested": 642,
+                "lines_accepted": 43,
+                "active_users": 4
+            },
+            {
+                "language": "yaml",
+                "editor": "vscode",
+                "suggestions_count": 403,
+                "acceptances_count": 128,
+                "lines_suggested": 1002,
+                "lines_accepted": 327,
+                "active_users": 15
+            },
+            {
+                "language": "json with comments",
+                "editor": "vscode",
+                "suggestions_count": 31,
+                "acceptances_count": 1,
+                "lines_suggested": 46,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "dotenv",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "vs-markdown",
+                "editor": "visual_studio",
+                "suggestions_count": 31,
+                "acceptances_count": 2,
+                "lines_suggested": 31,
+                "lines_accepted": 2,
+                "active_users": 2
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "jetbrains",
+                "suggestions_count": 247,
+                "acceptances_count": 59,
+                "lines_suggested": 409,
+                "lines_accepted": 117,
+                "active_users": 3
+            },
+            {
+                "language": "shell",
+                "editor": "jetbrains",
+                "suggestions_count": 4,
+                "acceptances_count": 0,
+                "lines_suggested": 6,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascript",
+                "editor": "jetbrains",
+                "suggestions_count": 5,
+                "acceptances_count": 1,
+                "lines_suggested": 5,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "python",
+                "editor": "jetbrains",
+                "suggestions_count": 2,
+                "acceptances_count": 1,
+                "lines_suggested": 2,
+                "lines_accepted": 1,
+                "active_users": 2
+            },
+            {
+                "language": "java",
+                "editor": "jetbrains",
+                "suggestions_count": 32,
+                "acceptances_count": 18,
+                "lines_suggested": 90,
+                "lines_accepted": 66,
+                "active_users": 3
+            },
+            {
+                "language": "c#",
+                "editor": "jetbrains",
+                "suggestions_count": 45,
+                "acceptances_count": 9,
+                "lines_suggested": 109,
+                "lines_accepted": 33,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "jetbrains",
+                "suggestions_count": 33,
+                "acceptances_count": 6,
+                "lines_suggested": 37,
+                "lines_accepted": 6,
+                "active_users": 2
+            },
+            {
+                "language": "yaml",
+                "editor": "jetbrains",
+                "suggestions_count": 3,
+                "acceptances_count": 2,
+                "lines_suggested": 4,
+                "lines_accepted": 3,
+                "active_users": 2
+            },
+            {
+                "language": "javascript",
+                "editor": "neovim",
+                "suggestions_count": 15,
+                "acceptances_count": 8,
+                "lines_suggested": 16,
+                "lines_accepted": 8,
+                "active_users": 2
+            },
+            {
+                "language": "emacs-lisp",
+                "editor": "emacs",
+                "suggestions_count": 3,
+                "acceptances_count": 2,
+                "lines_suggested": 3,
+                "lines_accepted": 2,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 104,
+        "total_chat_turns": 132,
+        "total_active_chat_users": 173
+    },
+    {
+        "day": "2024-04-13",
+        "total_suggestions_count": 2470,
+        "total_acceptances_count": 672,
+        "total_lines_suggested": 3756,
+        "total_lines_accepted": 880,
+        "total_active_users": 25,
+        "breakdown": [
+            {
+                "language": "postgres",
+                "editor": "vscode",
+                "suggestions_count": 6,
+                "acceptances_count": 0,
+                "lines_suggested": 12,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "typescriptreact",
+                "editor": "vscode",
+                "suggestions_count": 120,
+                "acceptances_count": 16,
+                "lines_suggested": 173,
+                "lines_accepted": 27,
+                "active_users": 6
+            },
+            {
+                "language": "unknown",
+                "editor": "vscode",
+                "suggestions_count": 75,
+                "acceptances_count": 24,
+                "lines_suggested": 111,
+                "lines_accepted": 35,
+                "active_users": 2
+            },
+            {
+                "language": "shell",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "javascript",
+                "editor": "vscode",
+                "suggestions_count": 56,
+                "acceptances_count": 14,
+                "lines_suggested": 104,
+                "lines_accepted": 34,
+                "active_users": 5
+            },
+            {
+                "language": "ruby",
+                "editor": "vscode",
+                "suggestions_count": 12,
+                "acceptances_count": 4,
+                "lines_suggested": 12,
+                "lines_accepted": 4,
+                "active_users": 3
+            },
+            {
+                "language": "python",
+                "editor": "vscode",
+                "suggestions_count": 124,
+                "acceptances_count": 48,
+                "lines_suggested": 168,
+                "lines_accepted": 74,
+                "active_users": 3
+            },
+            {
+                "language": "java",
+                "editor": "vscode",
+                "suggestions_count": 29,
+                "acceptances_count": 15,
+                "lines_suggested": 98,
+                "lines_accepted": 42,
+                "active_users": 3
+            },
+            {
+                "language": "r",
+                "editor": "vscode",
+                "suggestions_count": 67,
+                "acceptances_count": 5,
+                "lines_suggested": 89,
+                "lines_accepted": 5,
+                "active_users": 2
+            },
+            {
+                "language": "go",
+                "editor": "vscode",
+                "suggestions_count": 266,
+                "acceptances_count": 111,
+                "lines_suggested": 480,
+                "lines_accepted": 171,
+                "active_users": 3
+            },
+            {
+                "language": "rust",
+                "editor": "vscode",
+                "suggestions_count": 7,
+                "acceptances_count": 2,
+                "lines_suggested": 26,
+                "lines_accepted": 7,
+                "active_users": 2
+            },
+            {
+                "language": "typescript",
+                "editor": "vscode",
+                "suggestions_count": 215,
+                "acceptances_count": 43,
+                "lines_suggested": 259,
+                "lines_accepted": 48,
+                "active_users": 5
+            },
+            {
+                "language": "css",
+                "editor": "vscode",
+                "suggestions_count": 68,
+                "acceptances_count": 15,
+                "lines_suggested": 104,
+                "lines_accepted": 25,
+                "active_users": 3
+            },
+            {
+                "language": "markdown",
+                "editor": "vscode",
+                "suggestions_count": 1146,
+                "acceptances_count": 313,
+                "lines_suggested": 1571,
+                "lines_accepted": 321,
+                "active_users": 6
+            },
+            {
+                "language": "sql",
+                "editor": "vscode",
+                "suggestions_count": 45,
+                "acceptances_count": 17,
+                "lines_suggested": 76,
+                "lines_accepted": 33,
+                "active_users": 3
+            },
+            {
+                "language": "makefile",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "hcl",
+                "editor": "vscode",
+                "suggestions_count": 1,
+                "acceptances_count": 0,
+                "lines_suggested": 1,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "dockerfile",
+                "editor": "vscode",
+                "suggestions_count": 3,
+                "acceptances_count": 0,
+                "lines_suggested": 3,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "json",
+                "editor": "vscode",
+                "suggestions_count": 31,
+                "acceptances_count": 0,
+                "lines_suggested": 49,
+                "lines_accepted": 0,
+                "active_users": 1
+            },
+            {
+                "language": "text",
+                "editor": "vscode",
+                "suggestions_count": 102,
+                "acceptances_count": 18,
+                "lines_suggested": 282,
+                "lines_accepted": 25,
+                "active_users": 2
+            },
+            {
+                "language": "fsharp",
+                "editor": "visual_studio",
+                "suggestions_count": 93,
+                "acceptances_count": 27,
+                "lines_suggested": 134,
+                "lines_accepted": 29,
+                "active_users": 2
+            }
+        ],
+        "total_chat_acceptances": 92,
+        "total_chat_turns": 143,
+        "total_active_chat_users": 142
+    }
 ]

--- a/src/components/LanguagesBreakdown.vue
+++ b/src/components/LanguagesBreakdown.vue
@@ -28,13 +28,23 @@
                     <div class="text-overline mb-1" style="visibility: hidden;">filler</div>
                     <div class="text-h6 mb-1">Top 5 languages by accepted prompts</div>
                     <div style="width: 300px; height: 300px;" >
-                        <Pie :data="languagesChartDataTop5" :options="chartOptions" />
+                        <Pie :data="languagesChartDataTop5AcceptedPrompts" :options="chartOptions" />
+                    </div>
+                </v-card-item>
+            </v-card>
+
+            <v-card>
+                <v-card-item class="d-flex justify-center align-center">
+                    <div class="text-overline mb-1" style="visibility: hidden;">filler</div>
+                    <div class="text-h6 mb-1">Top 5 languages by acceptance rate</div>
+                    <div style="width: 300px; height: 300px;" >
+                        <Pie :data="languagesChartDataTop5AcceptanceRate" :options="chartOptions" />
                     </div>
                 </v-card-item>
             </v-card>
 
             <br>
-            <h2>Languages Breakdown | Sorted by Accepted Lines of Code</h2>
+            <h2>Languages Breakdown </h2>
             <br>
 
             <v-data-table :headers="headers" :items="Array.from(languages)" class="elevation-2">
@@ -118,7 +128,11 @@
       // Languages Chart Data for languages breakdown Pie Chart
       let languagesChartData = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });
 
-      let languagesChartDataTop5 = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });
+      //Top 5 by accepted prompts
+      let languagesChartDataTop5AcceptedPrompts = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });
+
+      //Top 5 by acceptance rate
+      let languagesChartDataTop5AcceptanceRate = ref<{ labels: string[]; datasets: any[] }>({ labels: [], datasets: [] });
   
       const chartOptions = {
         responsive: true,
@@ -152,10 +166,32 @@
           // Recalculate the acceptance rate
           language.acceptanceRate = language.suggestedLinesOfCode !== 0 ? (language.acceptedLinesOfCode / language.suggestedLinesOfCode) * 100 : 0;
         }));
-  
-        //Sort languages map by accepted lines of code
+
+        //Sort languages map by acceptance rate
         languages.value[Symbol.iterator] = function* () {
-          yield* [...this.entries()].sort((a, b) => b[1].acceptedLinesOfCode - a[1].acceptedLinesOfCode);
+          yield* [...this.entries()].sort((a, b) => b[1].acceptanceRate - a[1].acceptanceRate);
+        }
+
+
+        // Get the top 5 languages by acceptance rate
+        const top5LanguagesAcceptanceRate = new Map([...languages.value].slice(0, 5));
+
+        // Print the Map
+        console.log(Array.from(top5LanguagesAcceptanceRate.entries()));
+
+        languagesChartDataTop5AcceptanceRate.value = {
+          labels: Array.from(top5LanguagesAcceptanceRate.values()).map(language => language.languageName),
+          datasets: [
+            {
+              data: Array.from(top5LanguagesAcceptanceRate.values()).map(language => language.acceptanceRate.toFixed(2)),
+              backgroundColor: ['#41B883', '#E46651', '#00D8FF', '#DD1B16'],
+            },
+          ],
+        };
+  
+        //Sort languages map by accepted prompts
+        languages.value[Symbol.iterator] = function* () {
+          yield* [...this.entries()].sort((a, b) => b[1].acceptedPrompts - a[1].acceptedPrompts);
         }
 
         languagesChartData.value = {
@@ -169,17 +205,19 @@
         };
 
         // Get the top 5 languages by accepted prompts
-        const top5Languages = new Map([...languages.value].slice(0, 5));
+        const top5LanguagesAcceptedPrompts = new Map([...languages.value].slice(0, 5));
         
-        languagesChartDataTop5.value = {
-          labels: Array.from(top5Languages.values()).map(language => language.languageName),
+        languagesChartDataTop5AcceptedPrompts.value = {
+          labels: Array.from(top5LanguagesAcceptedPrompts.values()).map(language => language.languageName),
           datasets: [
             {
-              data: Array.from(top5Languages.values()).map(language => language.acceptedPrompts),
+              data: Array.from(top5LanguagesAcceptedPrompts.values()).map(language => language.acceptedPrompts),
               backgroundColor: ['#41B883', '#E46651', '#00D8FF', '#DD1B16'],
             },
           ],
         };
+
+
 
         numberOfLanguages.value = languages.value.size;
 
@@ -212,7 +250,8 @@
           
       });
   
-      return { apiError, chartOptions, languages, numberOfLanguages, languagesChartData, languagesChartDataTop5 };
+      return { apiError, chartOptions, languages, numberOfLanguages, 
+        languagesChartData, languagesChartDataTop5AcceptedPrompts, languagesChartDataTop5AcceptanceRate };
     },
     
   
@@ -234,14 +273,5 @@
     justify-content: flex-start;
     flex-wrap: wrap;
   }
-  
-  .tile {
-    border: 1px solid #ccc;
-    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.1), 
-                -3px -3px 5px rgba(255, 255, 255, 0.7);
-    padding: 20px;
-    border-radius: 10px;
-    width: 20%; 
-    margin: 1%;
-  }
+
   </style>


### PR DESCRIPTION
This pull request includes changes to the `src/assets/copilot_metrics_response_sample.json` and `src/components/LanguagesBreakdown.vue` files. The changes in the `copilot_metrics_response_sample.json` file add new metrics related to chat interactions, while the changes in the `LanguagesBreakdown.vue` file modify the way language data is presented and sorted.

Changes to `src/assets/copilot_metrics_response_sample.json`:

* Added chat metrics, including `total_chat_acceptances`, `total_chat_turns`, and `total_active_chat_users`, to multiple sections of the JSON data structure. This will provide more detailed metrics about chat usage. 
Changes to `src/components/LanguagesBreakdown.vue`:

* Added a new pie chart to display the top 5 languages by acceptance rate. [[1]](diffhunk://#diff-847369674e1670136d0a40efa29e0812f138aaa6d779c2d92ccb58380ba87020L31-R47) [[2]](diffhunk://#diff-847369674e1670136d0a40efa29e0812f138aaa6d779c2d92ccb58380ba87020L121-R135) [[3]](diffhunk://#diff-847369674e1670136d0a40efa29e0812f138aaa6d779c2d92ccb58380ba87020L156-R194)
* Renamed `languagesChartDataTop5` to `languagesChartDataTop5AcceptedPrompts` and adjusted the data it holds to reflect the name change. [[1]](diffhunk://#diff-847369674e1670136d0a40efa29e0812f138aaa6d779c2d92ccb58380ba87020L121-R135) [[2]](diffhunk://#diff-847369674e1670136d0a40efa29e0812f138aaa6d779c2d92ccb58380ba87020L172-R221)
* Removed the `.tile` CSS class.
* Updated the return statement to include `languagesChartDataTop5AcceptanceRate`.