### PR TITLE
Update nodejs version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 # build with 'docker build -t copilot-metrics .' for production
 ARG mode=prod
 
-FROM node:23-alpine AS build-stage
+FROM node:24-alpine AS build-stage
 
 USER node
 WORKDIR /app


### PR DESCRIPTION
According to https://nodejs.org/en/about/previous-releases, nodejs v23 is already end of life