### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -53,6 +53,8 @@ jobs:
         retention-days: 30
 
   test-docker-playwright:
+    permissions:
+      contents: read
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/github-copilot-resources/copilot-metrics-viewer/security/code-scanning/11](https://github.com/github-copilot-resources/copilot-metrics-viewer/security/code-scanning/11)

To fix the issue, an explicit `permissions` block should be added to the `test-docker-playwright` job in the workflow file. This block should define the least privileges necessary for the job to run correctly, which is likely limited to `contents: read`. The `permissions` block will prevent the job from inheriting potentially permissive repository-level permissions and adhere to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
