### PR TITLE
Improve "TEAMS" Dashboard Tab: Optimize Metrics Retrieval Based on GitHub Enterprise Type

### DIFF
--- a/.env
+++ b/.env
@@ -10,6 +10,11 @@ NUXT_PUBLIC_GITHUB_ORG=octodemo
 
 NUXT_PUBLIC_GITHUB_ENT=
 
+# Determines the GitHub Enterprise type for enterprise-scoped deployments.
+# Can be 'full' (GitHub Enterprise with full features) or 'copilot-only' (Copilot Business Only).
+# This affects how teams are retrieved and team metrics are accessed.
+NUXT_PUBLIC_ENTERPRISE_TYPE=copilot-only
+
 # Determines the team name if exists to target API calls.
 NUXT_PUBLIC_GITHUB_TEAM=
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -132,6 +132,39 @@ docker run -it --rm -p 3000:80 \
 ghcr.io/github-copilot-resources/copilot-metrics-viewer
 ```
 
+### Enterprise Type Configuration
+
+For enterprise deployments, you can specify the enterprise type to control how teams are retrieved and managed:
+
+**For Full GitHub Enterprises** (with repos, actions, copilot, etc):
+```bash
+docker run -it --rm -p 3000:80 \
+-e NUXT_PUBLIC_SCOPE=enterprise \
+-e NUXT_PUBLIC_GITHUB_ENT=<enterprise name> \
+-e NUXT_PUBLIC_ENTERPRISE_TYPE=full \
+-e NUXT_GITHUB_TOKEN=<github PAT> \
+-e NUXT_SESSION_PASSWORD=<random string - min 32 characters>  \
+ghcr.io/github-copilot-resources/copilot-metrics-viewer
+```
+
+**For Copilot Business Only Enterprises** (default behavior):
+```bash
+docker run -it --rm -p 3000:80 \
+-e NUXT_PUBLIC_SCOPE=enterprise \
+-e NUXT_PUBLIC_GITHUB_ENT=<enterprise name> \
+-e NUXT_PUBLIC_ENTERPRISE_TYPE=copilot-only \
+-e NUXT_GITHUB_TOKEN=<github PAT> \
+-e NUXT_SESSION_PASSWORD=<random string - min 32 characters>  \
+ghcr.io/github-copilot-resources/copilot-metrics-viewer
+```
+
+**Environment Variable Details:**
+- `NUXT_PUBLIC_ENTERPRISE_TYPE`: Set to `full` for Full GitHub Enterprises or `copilot-only` for Copilot Business Only enterprises
+- Default value: `copilot-only` (maintains backward compatibility)
+- This affects how teams are retrieved in the TEAMS tab:
+  - `full`: Enumerates organizations within the enterprise and fetches teams from each organization
+  - `copilot-only`: Uses enterprise-level teams API (existing behavior)
+
 ## Health Check Endpoints for Kubernetes
 
 The application provides dedicated health check endpoints for Kubernetes deployments that avoid triggering GitHub API calls:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,13 @@ Users can now filter metrics for custom date ranges up to 100 days, with an intu
 </p>
 
 ### Teams Comparison
-Compare Copilot metrics across multiple teams within your organization to understand adoption patterns and identify high-performing teams.
+Compare Copilot metrics across multiple teams within your organization or enterprise to understand adoption patterns and identify high-performing teams. 
+
+**Enterprise Support**: The application now supports both Full GitHub Enterprises and Copilot Business Only enterprises:
+- **Full Enterprises**: Teams are retrieved from all organizations within the enterprise
+- **Copilot Business Only**: Teams are retrieved using enterprise-level APIs
+
+Configure enterprise type using the `NUXT_PUBLIC_ENTERPRISE_TYPE` environment variable (`full` or `copilot-only`).
 
 <p align="center">
   <img width="800" alt="Teams Comparison" src="./images/teams-comparison.png">

--- a/app/model/Options.ts
+++ b/app/model/Options.ts
@@ -383,11 +383,11 @@ export class Options {
                 if (!this.githubEnt) {
                     throw new Error('GitHub enterprise must be set for enterprise scope');
                 }
-                // For full enterprises, we need to get teams from organizations within the enterprise
+                // For full enterprises, teams are fetched via GraphQL + organization teams APIs
                 // For copilot-only enterprises, we use the enterprise teams API
                 if (this.enterpriseType === 'full') {
-                    // This will be handled by the teams API to enumerate organizations first
-                    return `${baseUrl}/enterprises/${this.githubEnt}/organizations`;
+                    // GraphQL will be used to get organizations, then org teams APIs
+                    return `${baseUrl}/graphql`;
                 } else {
                     // Default to copilot-only behavior (enterprise teams API)
                     return `${baseUrl}/enterprises/${this.githubEnt}/teams`;
@@ -396,19 +396,6 @@ export class Options {
             default:
                 throw new Error(`Invalid scope: ${this.scope}`);
         }
-    }
-
-    /**
-     * Get the Enterprise Organizations API URL
-     */
-    getEnterpriseOrganizationsApiUrl(): string {
-        const baseUrl = 'https://api.github.com';
-        
-        if (!this.githubEnt) {
-            throw new Error('GitHub enterprise must be set');
-        }
-        
-        return `${baseUrl}/enterprises/${this.githubEnt}/organizations`;
     }
 
     /**

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -94,6 +94,7 @@ export default defineNuxtConfig({
       githubOrg: '',
       githubEnt: '',
       githubTeam: '',
+      enterpriseType: 'copilot-only',  // can be overridden by NUXT_PUBLIC_ENTERPRISE_TYPE environment variable
       usingGithubAuth: false,
       version,
       isPublicApp: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "nuxt-auth-utils": "^0.5.7",
         "roboto-fontface": "^0.10.0",
         "undici": ">=7.5.0",
-        "vue": "*",
+        "vue": "latest",
         "vue-chartjs": "^5.3.2",
         "vuetify": "^3.7.3",
         "webfontloader": "^1.6.28"

--- a/server/api/teams.ts
+++ b/server/api/teams.ts
@@ -1,8 +1,9 @@
-import { Options, type Scope } from '@/model/Options'
+import { Options, type Scope, type EnterpriseType } from '@/model/Options'
 import type { H3Event, EventHandlerRequest } from 'h3'
 
 interface Team { name: string; slug: string; description: string }
 interface GitHubTeam { name: string; slug: string; description?: string }
+interface GitHubOrganization { login: string; id: number }
 
 class TeamsError extends Error {
     statusCode: number
@@ -53,6 +54,7 @@ export async function getTeams(event: H3Event<EventHandlerRequest>): Promise<Tea
     if (!options.scope && config.public.scope) options.scope = config.public.scope as Scope
     if (!options.githubOrg && config.public.githubOrg) options.githubOrg = config.public.githubOrg
     if (!options.githubEnt && config.public.githubEnt) options.githubEnt = config.public.githubEnt
+    if (!options.enterpriseType && config.public.enterpriseType) options.enterpriseType = config.public.enterpriseType as EnterpriseType
 
     if (options.isDataMocked) {
         logger.info('Using mocked data for teams')
@@ -75,27 +77,80 @@ export async function getTeams(event: H3Event<EventHandlerRequest>): Promise<Tea
     const baseUrl = options.getTeamsApiUrl()
 
     const allTeams: Team[] = []
-    let nextUrl: string | null = `${baseUrl}?per_page=100`
-    let page = 1
-
-    while (nextUrl) {
-        logger.info(`Fetching teams page ${page} from ${nextUrl}`)
-        const res = await $fetch.raw(nextUrl, {
-            headers: event.context.headers
-        })
-
-        const data = res._data as GitHubTeam[]
-        for (const t of data) {
-            const name: string = t.name
-            const slug: string = t.slug
-            const description: string = t.description || ''
-            if (name && slug) allTeams.push({ name, slug, description })
+    
+    // Handle enterprise scope with different enterprise types
+    if ((options.scope === 'enterprise' || options.scope === 'team-enterprise') && options.enterpriseType === 'full') {
+        // For full enterprises, we need to enumerate organizations and get teams from each
+        const orgsUrl = options.getEnterpriseOrganizationsApiUrl()
+        
+        logger.info(`Fetching organizations for full enterprise from ${orgsUrl}`)
+        let nextOrgsUrl: string | null = `${orgsUrl}?per_page=100`
+        let orgsPage = 1
+        
+        while (nextOrgsUrl) {
+            logger.info(`Fetching organizations page ${orgsPage} from ${nextOrgsUrl}`)
+            const orgsRes = await $fetch.raw(nextOrgsUrl, {
+                headers: event.context.headers
+            })
+            
+            const orgsData = orgsRes._data as GitHubOrganization[]
+            
+            // For each organization, fetch its teams
+            for (const org of orgsData) {
+                const orgTeamsUrl = `https://api.github.com/orgs/${org.login}/teams`
+                let nextTeamsUrl: string | null = `${orgTeamsUrl}?per_page=100`
+                let teamsPage = 1
+                
+                while (nextTeamsUrl) {
+                    logger.info(`Fetching teams page ${teamsPage} from ${nextTeamsUrl} for org ${org.login}`)
+                    const teamsRes = await $fetch.raw(nextTeamsUrl, {
+                        headers: event.context.headers
+                    })
+                    
+                    const teamsData = teamsRes._data as GitHubTeam[]
+                    for (const t of teamsData) {
+                        const name: string = `${org.login} - ${t.name}`
+                        const slug: string = `${org.login} - ${t.slug}`
+                        const description: string = t.description || `Team ${t.name} from organization ${org.login}`
+                        if (t.name && t.slug) allTeams.push({ name, slug, description })
+                    }
+                    
+                    const teamsLinkHeader = teamsRes.headers.get('link') || teamsRes.headers.get('Link')
+                    const teamsLinks = parseLinkHeader(teamsLinkHeader)
+                    nextTeamsUrl = teamsLinks['next'] || null
+                    teamsPage += 1
+                }
+            }
+            
+            const orgsLinkHeader = orgsRes.headers.get('link') || orgsRes.headers.get('Link')
+            const orgsLinks = parseLinkHeader(orgsLinkHeader)
+            nextOrgsUrl = orgsLinks['next'] || null
+            orgsPage += 1
         }
+    } else {
+        // Handle organization scope or copilot-only enterprise scope (original logic)
+        let nextUrl: string | null = `${baseUrl}?per_page=100`
+        let page = 1
 
-        const linkHeader = res.headers.get('link') || res.headers.get('Link')
-        const links = parseLinkHeader(linkHeader)
-        nextUrl = links['next'] || null
-        page += 1
+        while (nextUrl) {
+            logger.info(`Fetching teams page ${page} from ${nextUrl}`)
+            const res = await $fetch.raw(nextUrl, {
+                headers: event.context.headers
+            })
+
+            const data = res._data as GitHubTeam[]
+            for (const t of data) {
+                const name: string = t.name
+                const slug: string = t.slug
+                const description: string = t.description || ''
+                if (name && slug) allTeams.push({ name, slug, description })
+            }
+
+            const linkHeader = res.headers.get('link') || res.headers.get('Link')
+            const links = parseLinkHeader(linkHeader)
+            nextUrl = links['next'] || null
+            page += 1
+        }
     }
 
     return allTeams

--- a/server/api/teams.ts
+++ b/server/api/teams.ts
@@ -98,10 +98,7 @@ export async function getTeams(event: H3Event<EventHandlerRequest>): Promise<Tea
         
         const graphqlResponse = await $fetch<GraphQLResponse>('https://api.github.com/graphql', {
             method: 'POST',
-            headers: {
-                ...event.context.headers,
-                'Content-Type': 'application/json'
-            },
+            headers: event.context.headers,
             body: JSON.stringify(graphqlQuery)
         })
         

--- a/tests/enterprise-type.spec.ts
+++ b/tests/enterprise-type.spec.ts
@@ -22,7 +22,7 @@ describe('Enterprise Type Support', () => {
       })
 
       expect(options.enterpriseType).toBe('full')
-      expect(options.getTeamsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/organizations')
+      expect(options.getTeamsApiUrl()).toBe('https://api.github.com/graphql')
     })
 
     it('should default to copilot-only behavior when enterprise type not specified', () => {
@@ -117,20 +117,6 @@ describe('Enterprise Type Support', () => {
 
       const merged = options1.merge(options2)
       expect(merged.enterpriseType).toBe('full')
-    })
-
-    it('should handle enterprise organizations API URL', () => {
-      const options = new Options({
-        githubEnt: 'test-enterprise'
-      })
-
-      expect(options.getEnterpriseOrganizationsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/organizations')
-    })
-
-    it('should throw error for enterprise organizations API without enterprise', () => {
-      const options = new Options()
-
-      expect(() => options.getEnterpriseOrganizationsApiUrl()).toThrow('GitHub enterprise must be set')
     })
   })
 })

--- a/tests/enterprise-type.spec.ts
+++ b/tests/enterprise-type.spec.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import { Options } from '@/model/Options'
+
+describe('Enterprise Type Support', () => {
+  describe('Options class enterprise type handling', () => {
+    it('should handle copilot-only enterprise type', () => {
+      const options = new Options({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise',
+        enterpriseType: 'copilot-only'
+      })
+
+      expect(options.enterpriseType).toBe('copilot-only')
+      expect(options.getTeamsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/teams')
+    })
+
+    it('should handle full enterprise type', () => {
+      const options = new Options({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise',
+        enterpriseType: 'full'
+      })
+
+      expect(options.enterpriseType).toBe('full')
+      expect(options.getTeamsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/organizations')
+    })
+
+    it('should default to copilot-only behavior when enterprise type not specified', () => {
+      const options = new Options({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise'
+      })
+
+      expect(options.getTeamsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/teams')
+    })
+
+    it('should handle team-enterprise scope with copilot-only type', () => {
+      const options = new Options({
+        scope: 'team-enterprise',
+        githubEnt: 'test-enterprise',
+        githubTeam: 'test-team',
+        enterpriseType: 'copilot-only'
+      })
+
+      expect(options.getApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/team/test-team/copilot/metrics')
+    })
+
+    it('should handle team-enterprise scope with full type', () => {
+      const options = new Options({
+        scope: 'team-enterprise',
+        githubEnt: 'test-enterprise',
+        githubTeam: 'org-name - team-name',
+        enterpriseType: 'full'
+      })
+
+      expect(options.getApiUrl()).toBe('https://api.github.com/orgs/org-name/team/team-name/copilot/metrics')
+    })
+
+    it('should throw error for invalid team slug format in full enterprise', () => {
+      const options = new Options({
+        scope: 'team-enterprise',
+        githubEnt: 'test-enterprise',
+        githubTeam: 'invalid-team-slug',
+        enterpriseType: 'full'
+      })
+
+      expect(() => options.getApiUrl()).toThrow('Team slug must be in format "org-name - team-name" for full enterprise scope')
+    })
+
+    it('should include enterprise type in serialization methods', () => {
+      const options = new Options({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise',
+        enterpriseType: 'full'
+      })
+
+      const params = options.toParams()
+      expect(params.enterpriseType).toBe('full')
+
+      const urlParams = options.toURLSearchParams()
+      expect(urlParams.get('enterpriseType')).toBe('full')
+
+      const obj = options.toObject()
+      expect(obj.enterpriseType).toBe('full')
+    })
+
+    it('should handle enterprise type in fromQuery method', () => {
+      const options = Options.fromQuery({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise',
+        enterpriseType: 'full'
+      })
+
+      expect(options.enterpriseType).toBe('full')
+    })
+
+    it('should handle enterprise type in fromURLSearchParams method', () => {
+      const params = new URLSearchParams()
+      params.set('scope', 'enterprise')
+      params.set('githubEnt', 'test-enterprise')
+      params.set('enterpriseType', 'full')
+
+      const options = Options.fromURLSearchParams(params)
+      expect(options.enterpriseType).toBe('full')
+    })
+
+    it('should handle enterprise type in merge method', () => {
+      const options1 = new Options({
+        scope: 'enterprise',
+        githubEnt: 'test-enterprise',
+        enterpriseType: 'copilot-only'
+      })
+
+      const options2 = new Options({
+        enterpriseType: 'full'
+      })
+
+      const merged = options1.merge(options2)
+      expect(merged.enterpriseType).toBe('full')
+    })
+
+    it('should handle enterprise organizations API URL', () => {
+      const options = new Options({
+        githubEnt: 'test-enterprise'
+      })
+
+      expect(options.getEnterpriseOrganizationsApiUrl()).toBe('https://api.github.com/enterprises/test-enterprise/organizations')
+    })
+
+    it('should throw error for enterprise organizations API without enterprise', () => {
+      const options = new Options()
+
+      expect(() => options.getEnterpriseOrganizationsApiUrl()).toThrow('GitHub enterprise must be set')
+    })
+  })
+})


### PR DESCRIPTION
This pull request adds support for distinguishing between "Full GitHub Enterprises" and "Copilot Business Only" enterprises, enabling more accurate team retrieval and metrics for each enterprise type. The change introduces a new `enterpriseType` option throughout the configuration, API, and model layers, updates documentation, and provides comprehensive tests for the new logic.

**Enterprise Type Support and API Logic:**

* Added `NUXT_PUBLIC_ENTERPRISE_TYPE` environment variable and propagated its usage throughout the codebase to distinguish between `full` and `copilot-only` enterprise types, affecting how teams and metrics are retrieved. (`.env`, `nuxt.config.ts`, [[1]](diffhunk://#diff-e9cbb0224c4a3d23a6019ba557e0cd568c1ad5e1582ff1e335fb7d99b7a1055dR13-R17) [[2]](diffhunk://#diff-5977891bf10802cdd3cde62f0355105a1662e65b02ae4fb404a27bb0f5f53a07R97)
* Updated `Options` model to include `enterpriseType`, with serialization, deserialization, and merging logic, and modified API URL construction to support both enterprise types for team and enterprise scopes. (`app/model/Options.ts`, [[1]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR9) [[2]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR19) [[3]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR30) [[4]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR60) [[5]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR72) [[6]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR117) [[7]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR135) [[8]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR159) [[9]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR195) [[10]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR211) [[11]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR230) [[12]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR256) [[13]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR302-R318) [[14]](diffhunk://#diff-eee939da81564c0aa71140a8cc7c1217ef2551f53cc0da69e4aa3702298c160fR386-R394)

**Backend Team Retrieval Logic:**

* Enhanced the teams API handler to use GraphQL for enumerating organizations and fetching teams for full enterprises, while maintaining existing logic for copilot-only enterprises and organizations. (`server/api/teams.ts`, [[1]](diffhunk://#diff-a8eae7a12afb66ab58e4bb64335583ce867e3c20d8231dc4c7cab49f16212b91L1-R15) [[2]](diffhunk://#diff-a8eae7a12afb66ab58e4bb64335583ce867e3c20d8231dc4c7cab49f16212b91R66) [[3]](diffhunk://#diff-a8eae7a12afb66ab58e4bb64335583ce867e3c20d8231dc4c7cab49f16212b91R89-R135) [[4]](diffhunk://#diff-a8eae7a12afb66ab58e4bb64335583ce867e3c20d8231dc4c7cab49f16212b91R158)

**Documentation Updates:**

* Updated deployment and README documentation to explain the new enterprise type configuration, usage, and behavioral differences for team retrieval and metrics. (`DEPLOYMENT.md`, [[1]](diffhunk://#diff-04615394c116398fb5fcb0aa2d880df854202e4c94907dc81cd2647101ad3306R135-R167); `README.md`, [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R34)

**Testing:**

* Added comprehensive tests for `Options` enterprise type handling, including serialization, merging, API URL logic, and error cases. (`tests/enterprise-type.spec.ts`, [tests/enterprise-type.spec.tsR1-R122](diffhunk://#diff-9975a955bac2afa61afc676d0d0f5706aa32f133d8b6fb7ce9dc7121ba9030a8R1-R122))


@karpikpl as discussed this is a first implementation created with the help of Coding Agent and tested by myself in a Codespaces, should start to address #271, please verify it.

NOTE: A new scope is required for the GitHub Token (read:org)