### PR TITLE
Add multi-organization scope support with metrics aggregation and user deduplication + Champions page

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Public variables:
 - `NUXT_PUBLIC_SCOPE`
 - `NUXT_PUBLIC_GITHUB_ENT`
 - `NUXT_PUBLIC_GITHUB_ORG`
+- `NUXT_PUBLIC_GITHUB_ORGS`
 - `NUXT_PUBLIC_GITHUB_TEAM`
 
 can be overridden by route parameters, e.g.
@@ -167,11 +168,12 @@ can be overridden by route parameters, e.g.
 
 #### NUXT_PUBLIC_SCOPE (Required!)
 
-The `NUXT_PUBLIC_SCOPE` environment variable in the `.env` file determines the default scope of the API calls made by the application. It can be set to 'enterprise', 'organization', 'team-organization' or 'team-enterprise'.
+The `NUXT_PUBLIC_SCOPE` environment variable in the `.env` file determines the default scope of the API calls made by the application. It can be set to 'enterprise', 'organization', 'team-organization', 'team-enterprise', or 'multi-organization'.
 
 - If set to 'enterprise', the application will target API calls to the GitHub Enterprise account defined in the `NUXT_PUBLIC_GITHUB_ENT` variable.
 - If set to 'organization', the application will target API calls to the GitHub Organization account defined in the `NUXT_PUBLIC_GITHUB_ORG` variable.
-- If set to 'team', the application will target API calls to GitHub Team defined in the `NUXT_PUBLIC_GITHUB_TEAM` variable under `NUXT_PUBLIC_GITHUB_ORG` GitHub Organization.
+- If set to 'team-organization' or 'team-enterprise', the application will target API calls to GitHub Team defined in the `NUXT_PUBLIC_GITHUB_TEAM` variable under the respective organization or enterprise.
+- If set to 'multi-organization', the application will aggregate metrics from multiple organizations defined in `NUXT_PUBLIC_GITHUB_ORGS` (comma-separated list).
 
 For example, if you want to target the API calls to an organization, you would set `NUXT_PUBLIC_SCOPE=organization` in the `.env` file.
 
@@ -186,6 +188,22 @@ NUXT_PUBLIC_GITHUB_ORG=<YOUR-ORGANIZATION>
 
 NUXT_PUBLIC_GITHUB_ENT=
 ````
+
+#### NUXT_PUBLIC_GITHUB_ORGS (For Multi-Organization Support)
+
+The `NUXT_PUBLIC_GITHUB_ORGS` environment variable allows you to specify multiple GitHub organizations as a comma-separated list. When two or more organizations are provided, the application will automatically use the 'multi-organization' scope and aggregate metrics from all specified organizations.
+
+>[!TIP]
+> This is perfect for getting a combined view of Copilot usage across multiple organizations within your company.
+
+**Example for multiple organizations:**
+````
+NUXT_PUBLIC_GITHUB_ORGS=org1,org2,org3
+NUXT_PUBLIC_SCOPE=multi-organization
+````
+
+>[!NOTE]
+> When `NUXT_PUBLIC_GITHUB_ORGS` contains 2+ organizations, the scope will automatically be set to 'multi-organization' regardless of the `NUXT_PUBLIC_SCOPE` value.
 
 #### NUXT_PUBLIC_GITHUB_TEAM
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,6 @@ Public variables:
 - `NUXT_PUBLIC_SCOPE`
 - `NUXT_PUBLIC_GITHUB_ENT`
 - `NUXT_PUBLIC_GITHUB_ORG`
-- `NUXT_PUBLIC_GITHUB_ORGS`
 - `NUXT_PUBLIC_GITHUB_TEAM`
 
 can be overridden by route parameters, e.g.
@@ -173,7 +172,7 @@ The `NUXT_PUBLIC_SCOPE` environment variable in the `.env` file determines the d
 - If set to 'enterprise', the application will target API calls to the GitHub Enterprise account defined in the `NUXT_PUBLIC_GITHUB_ENT` variable.
 - If set to 'organization', the application will target API calls to the GitHub Organization account defined in the `NUXT_PUBLIC_GITHUB_ORG` variable.
 - If set to 'team-organization' or 'team-enterprise', the application will target API calls to GitHub Team defined in the `NUXT_PUBLIC_GITHUB_TEAM` variable under the respective organization or enterprise.
-- If set to 'multi-organization', the application will aggregate metrics from multiple organizations defined in `NUXT_PUBLIC_GITHUB_ORGS` (comma-separated list).
+- If set to 'multi-organization', the application will aggregate metrics from multiple organizations defined in `NUXT_PUBLIC_GITHUB_ORG` as a comma-separated list.
 
 For example, if you want to target the API calls to an organization, you would set `NUXT_PUBLIC_SCOPE=organization` in the `.env` file.
 
@@ -189,21 +188,32 @@ NUXT_PUBLIC_GITHUB_ORG=<YOUR-ORGANIZATION>
 NUXT_PUBLIC_GITHUB_ENT=
 ````
 
-#### NUXT_PUBLIC_GITHUB_ORGS (For Multi-Organization Support)
+#### NUXT_PUBLIC_GITHUB_ORG (Required for Organization/Multi-Organization Scope)
 
-The `NUXT_PUBLIC_GITHUB_ORGS` environment variable allows you to specify multiple GitHub organizations as a comma-separated list. When two or more organizations are provided, the application will automatically use the 'multi-organization' scope and aggregate metrics from all specified organizations.
+The `NUXT_PUBLIC_GITHUB_ORG` environment variable specifies the GitHub organization(s) to target:
+
+- **Single Organization:** Set it to a single organization name
+- **Multiple Organizations:** Set it to a comma-separated list of organization names
+
+When two or more organizations are provided (comma-separated), the application will automatically use the 'multi-organization' scope and aggregate metrics from all specified organizations.
 
 >[!TIP]
 > This is perfect for getting a combined view of Copilot usage across multiple organizations within your company.
 
+**Example for single organization:**
+````
+NUXT_PUBLIC_GITHUB_ORG=my-org
+NUXT_PUBLIC_SCOPE=organization
+````
+
 **Example for multiple organizations:**
 ````
-NUXT_PUBLIC_GITHUB_ORGS=org1,org2,org3
+NUXT_PUBLIC_GITHUB_ORG=org1,org2,org3
 NUXT_PUBLIC_SCOPE=multi-organization
 ````
 
 >[!NOTE]
-> When `NUXT_PUBLIC_GITHUB_ORGS` contains 2+ organizations, the scope will automatically be set to 'multi-organization' regardless of the `NUXT_PUBLIC_SCOPE` value.
+> When `NUXT_PUBLIC_GITHUB_ORG` contains 2+ organizations (comma-separated), the scope will automatically be set to 'multi-organization' regardless of the `NUXT_PUBLIC_SCOPE` value.
 
 #### NUXT_PUBLIC_GITHUB_TEAM
 

--- a/app/components/AgentModeViewer.vue
+++ b/app/components/AgentModeViewer.vue
@@ -49,14 +49,14 @@
                                         </template>
                                         <v-card class="pa-2" style="background-color: #f0f0f0; max-width: 350px;">
                                             <span class="text-caption" style="font-size: 10px !important;">
-                                                Statistics for code completions in integrated development environments.
+                                                Average daily users for code completions in integrated development environments.
                                             </span>
                                         </v-card>
                                     </v-tooltip>
                                 </v-card-title>
                                 <v-card-text>
                                     <div class="text-h4 mb-2">{{ stats.totalIdeCodeCompletionUsers }}</div>
-                                    <div class="text-caption">Total Users with Activity</div>
+                                    <div class="text-caption">Average Daily Users with Activity</div>
                                     <div class="text-subtitle2 mt-2">{{ stats.totalIdeCodeCompletionModels }} Models
                                         Used</div>
                                 </v-card-text>
@@ -71,14 +71,14 @@
                                         </template>
                                         <v-card class="pa-2" style="background-color: #f0f0f0; max-width: 350px;">
                                             <span class="text-caption" style="font-size: 10px !important;">
-                                                Statistics for chat interactions in integrated development environments.
+                                                Average daily users for chat interactions in integrated development environments.
                                             </span>
                                         </v-card>
                                     </v-tooltip>
                                 </v-card-title>
                                 <v-card-text>
                                     <div class="text-h4 mb-2">{{ stats.totalIdeChatUsers }}</div>
-                                    <div class="text-caption">Total Users with Activity</div>
+                                    <div class="text-caption">Average Daily Users with Activity</div>
                                     <div class="text-subtitle2 mt-2">{{ stats.totalIdeChatModels }} Models Used</div>
                                 </v-card-text>
                             </v-card>
@@ -92,14 +92,14 @@
                                         </template>
                                         <v-card class="pa-2" style="background-color: #f0f0f0; max-width: 350px;">
                                             <span class="text-caption" style="font-size: 10px !important;">
-                                                Statistics for chat interactions on GitHub.com web interface.
+                                                Average daily users for chat interactions on GitHub.com web interface.
                                             </span>
                                         </v-card>
                                     </v-tooltip>
                                 </v-card-title>
                                 <v-card-text>
                                     <div class="text-h4 mb-2">{{ stats.totalDotcomChatUsers }}</div>
-                                    <div class="text-caption">Total Users with Activity</div>
+                                    <div class="text-caption">Average Daily Users with Activity</div>
                                     <div class="text-subtitle2 mt-2">{{ stats.totalDotcomChatModels }} Models Used</div>
                                 </v-card-text>
                             </v-card>
@@ -409,14 +409,14 @@ export default defineComponent({
             { title: 'Model Name', key: 'name' },
             { title: 'Editor', key: 'editor' },
             { title: 'Type', key: 'model_type' },
-            { title: 'Total Users with Activity', key: 'total_engaged_users' }
+            { title: 'Avg Daily Users with Activity', key: 'total_engaged_users' }
         ];
 
         const ideChatHeaders = [
             { title: 'Model Name', key: 'name' },
             { title: 'Editor', key: 'editor' },
             { title: 'Type', key: 'model_type' },
-            { title: 'Total Users with Activity', key: 'total_engaged_users' },
+            { title: 'Avg Daily Users with Activity', key: 'total_engaged_users' },
             { title: 'Total Chats', key: 'total_chats' },
             { title: 'Insertions', key: 'total_chat_insertion_events' },
             { title: 'Copy Events', key: 'total_chat_copy_events' }
@@ -425,7 +425,7 @@ export default defineComponent({
         const dotcomChatHeaders = [
             { title: 'Model Name', key: 'name' },
             { title: 'Type', key: 'model_type' },
-            { title: 'Total Users with Activity', key: 'total_engaged_users' },
+            { title: 'Avg Daily Users with Activity', key: 'total_engaged_users' },
             { title: 'Total Chats', key: 'total_chats' }
         ];
 
@@ -433,7 +433,7 @@ export default defineComponent({
             { title: 'Model Name', key: 'name' },
             { title: 'Repository', key: 'repository' },
             { title: 'Type', key: 'model_type' },
-            { title: 'Total Users with Activity', key: 'total_engaged_users' },
+            { title: 'Avg Daily Users with Activity', key: 'total_engaged_users' },
             { title: 'PR Summaries', key: 'total_pr_summaries_created' }
         ];
 

--- a/app/components/ChampionsViewer.vue
+++ b/app/components/ChampionsViewer.vue
@@ -1,0 +1,501 @@
+<template>
+  <div>
+    <!-- Top 5 Teams Section -->
+    <v-container>
+      <v-row>
+        <v-col cols="12">
+          <v-card class="mb-4 top-champions-card">
+            <v-card-title class="text-h5 d-flex align-center">
+              <v-icon size="32" color="amber" class="mr-2">mdi-trophy</v-icon>
+              Top 5 Teams by Acceptance Rate
+            </v-card-title>
+            <v-card-subtitle>
+              Teams with the highest average acceptance rate {{ dateRangeDescription }}
+            </v-card-subtitle>
+            <v-card-text>
+              <v-row v-if="topTeams.length > 0">
+                <v-col
+                  v-for="(team, index) in topTeams"
+                  :key="team.uniqueId"
+                  cols="12"
+                  sm="6"
+                  md="4"
+                  lg="2"
+                >
+                  <v-card
+                    :class="['champion-card', `champion-rank-${index + 1}`]"
+                    elevation="3"
+                  >
+                    <v-card-text class="text-center">
+                      <div class="rank-badge">
+                        <v-icon
+                          v-if="index === 0"
+                          size="48"
+                          color="amber-darken-2"
+                        >
+                          mdi-trophy
+                        </v-icon>
+                        <v-icon
+                          v-else-if="index === 1"
+                          size="40"
+                          color="grey-lighten-1"
+                        >
+                          mdi-medal
+                        </v-icon>
+                        <v-icon
+                          v-else-if="index === 2"
+                          size="36"
+                          color="orange-darken-3"
+                        >
+                          mdi-medal
+                        </v-icon>
+                        <span v-else class="rank-number">#{{ index + 1 }}</span>
+                      </div>
+                      <h3 class="text-h6 mt-2 mb-1 team-name">{{ team.displayName }}</h3>
+                      <div class="acceptance-rate">
+                        <span class="rate-value">{{ team.acceptanceRate.toFixed(1) }}%</span>
+                      </div>
+                      <v-divider class="my-2" />
+                      <div class="team-stats">
+                        <div class="stat-item">
+                          <v-icon size="16" class="mr-1">mdi-account-group</v-icon>
+                          <span class="text-caption">{{ team.avgActiveUsers }} users</span>
+                        </div>
+                      </div>
+                      <v-btn
+                        :href="getTeamDetailUrl(team)"
+                        target="_blank"
+                        variant="text"
+                        size="small"
+                        color="primary"
+                        class="mt-2"
+                      >
+                        View Details
+                        <v-icon end size="16">mdi-open-in-new</v-icon>
+                      </v-btn>
+                    </v-card-text>
+                  </v-card>
+                </v-col>
+              </v-row>
+              <v-alert
+                v-else
+                type="info"
+                variant="tonal"
+                class="mt-4"
+              >
+                No team data available for the selected date range
+              </v-alert>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+
+    <!-- All Teams Table -->
+    <v-container>
+      <v-row>
+        <v-col cols="12">
+          <v-card>
+            <v-card-title class="text-h5">All Teams Leaderboard</v-card-title>
+            <v-card-subtitle>
+              Complete ranking of all teams by acceptance rate
+            </v-card-subtitle>
+            <v-card-text>
+              <!-- Search Filter -->
+              <v-text-field
+                v-model="searchQuery"
+                label="Filter by team name"
+                prepend-inner-icon="mdi-magnify"
+                variant="outlined"
+                density="compact"
+                clearable
+                class="mb-4"
+                hide-details
+              />
+
+              <!-- Data Table -->
+              <v-data-table
+                :headers="tableHeaders"
+                :items="filteredTeams"
+                :search="searchQuery"
+                :items-per-page="10"
+                :loading="isLoading"
+                class="elevation-1"
+              >
+                <template #item.rank="{ item }">
+                  <div class="d-flex align-center">
+                    <v-icon
+                      v-if="item.rank === 1"
+                      color="amber-darken-2"
+                      class="mr-1"
+                    >
+                      mdi-trophy
+                    </v-icon>
+                    <v-icon
+                      v-else-if="item.rank === 2"
+                      color="grey-lighten-1"
+                      class="mr-1"
+                    >
+                      mdi-medal
+                    </v-icon>
+                    <v-icon
+                      v-else-if="item.rank === 3"
+                      color="orange-darken-3"
+                      class="mr-1"
+                    >
+                      mdi-medal
+                    </v-icon>
+                    <span class="font-weight-bold">{{ item.rank }}</span>
+                  </div>
+                </template>
+
+                <template #item.displayName="{ item }">
+                  <div class="team-name-cell">
+                    <div class="font-weight-medium">{{ item.displayName }}</div>
+                    <div v-if="item.description" class="text-caption text-medium-emphasis">
+                      {{ item.description }}
+                    </div>
+                  </div>
+                </template>
+
+                <template #item.acceptanceRate="{ item }">
+                  <v-chip
+                    :color="getAcceptanceRateColor(item.acceptanceRate)"
+                    variant="flat"
+                    size="small"
+                  >
+                    {{ item.acceptanceRate.toFixed(1) }}%
+                  </v-chip>
+                </template>
+
+                <template #item.avgActiveUsers="{ item }">
+                  <div class="d-flex align-center">
+                    <v-icon size="16" class="mr-1">mdi-account-group</v-icon>
+                    {{ item.avgActiveUsers }}
+                  </div>
+                </template>
+
+                <template #item.actions="{ item }">
+                  <v-btn
+                    :href="getTeamDetailUrl(item)"
+                    target="_blank"
+                    variant="text"
+                    size="small"
+                    color="primary"
+                  >
+                    Details
+                    <v-icon end size="16">mdi-open-in-new</v-icon>
+                  </v-btn>
+                </template>
+
+                <template #no-data>
+                  <v-alert type="info" variant="tonal" class="ma-4">
+                    No teams found. Adjust your filters or check your date range.
+                  </v-alert>
+                </template>
+              </v-data-table>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, onMounted, watch, type PropType } from 'vue'
+import { Options } from '@/model/Options'
+import type { MetricsApiResponse } from '@/types/metricsApiResponse'
+import type { Metrics } from '@/model/Metrics'
+
+interface DateRange {
+  since?: string
+  until?: string
+}
+
+interface Team {
+  name: string
+  slug: string
+  description?: string
+  organization?: string
+  uniqueId?: string
+  displayName?: string
+}
+
+interface TeamWithMetrics extends Team {
+  acceptanceRate: number
+  avgActiveUsers: number
+  rank: number
+}
+
+export default defineComponent({
+  name: 'ChampionsViewer',
+  props: {
+    dateRange: {
+      type: Object as PropType<DateRange>,
+      required: false,
+      default: () => ({})
+    },
+    dateRangeDescription: {
+      type: String,
+      default: 'Over the last 28 days'
+    }
+  },
+  setup(props) {
+    const availableTeams = ref<Team[]>([])
+    const teamsWithMetrics = ref<TeamWithMetrics[]>([])
+    const isLoading = ref(false)
+    const searchQuery = ref('')
+
+    const tableHeaders = [
+      { title: 'Rank', key: 'rank', sortable: true, width: '100px' },
+      { title: 'Team Name', key: 'displayName', sortable: true },
+      { title: 'Acceptance Rate', key: 'acceptanceRate', sortable: true, align: 'center' },
+      { title: 'Avg Active Users', key: 'avgActiveUsers', sortable: true, align: 'center' },
+      { title: 'Actions', key: 'actions', sortable: false, align: 'center' }
+    ]
+
+    const topTeams = computed(() => {
+      return teamsWithMetrics.value.slice(0, 5)
+    })
+
+    const filteredTeams = computed(() => {
+      if (!searchQuery.value) {
+        return teamsWithMetrics.value
+      }
+      const query = searchQuery.value.toLowerCase()
+      return teamsWithMetrics.value.filter(team =>
+        team.displayName?.toLowerCase().includes(query) ||
+        team.name.toLowerCase().includes(query) ||
+        team.description?.toLowerCase().includes(query)
+      )
+    })
+
+    const getAcceptanceRateColor = (rate: number): string => {
+      if (rate >= 80) return 'success'
+      if (rate >= 60) return 'info'
+      if (rate >= 40) return 'warning'
+      return 'error'
+    }
+
+    const getTeamDetailUrl = (team: Team | TeamWithMetrics) => {
+      const config = useRuntimeConfig()
+      const org = team.organization || config.public.githubOrg
+      const ent = config.public.githubEnt
+
+      if (config.public.scope === 'enterprise' || config.public.scope === 'team-enterprise') {
+        return `/enterprises/${ent}/teams/${team.slug}`
+      }
+      return `/orgs/${org}/teams/${team.slug}`
+    }
+
+    const loadTeams = async () => {
+      const route = useRoute()
+      const options = Options.fromRoute(route, props.dateRange.since, props.dateRange.until)
+      const params = options.toParams()
+
+      const teams = await $fetch<Team[]>('/api/teams', { params })
+
+      const config = useRuntimeConfig()
+      const isMultiOrg = config.public.scope === 'multi-organization'
+
+      availableTeams.value = teams.map(team => ({
+        ...team,
+        uniqueId: team.organization ? `${team.organization}/${team.slug}` : team.slug,
+        displayName: team.organization && isMultiOrg ? `${team.name} (${team.organization})` : team.name
+      }))
+    }
+
+    const loadMetricsForTeam = async (team: Team): Promise<{ acceptanceRate: number; avgActiveUsers: number }> => {
+      const route = useRoute()
+      const options = Options.fromRoute(route, props.dateRange.since, props.dateRange.until)
+
+      // Force scope to team variant based on current broader scope
+      if (options.scope === 'enterprise') {
+        options.scope = 'team-enterprise'
+      } else if (options.scope === 'organization' || options.scope === 'multi-organization') {
+        options.scope = 'team-organization'
+        if (team.organization) {
+          options.githubOrg = team.organization
+        } else if (options.githubOrgs && options.githubOrgs.length > 0) {
+          options.githubOrg = options.githubOrgs[0]
+        }
+      }
+
+      options.githubTeam = team.slug
+      const params = options.toParams()
+
+      try {
+        const response = await $fetch<MetricsApiResponse>('/api/metrics', { params })
+        const metrics = (response.metrics as Metrics[]) || []
+
+        if (metrics.length === 0) {
+          return { acceptanceRate: 0, avgActiveUsers: 0 }
+        }
+
+        // Calculate average acceptance rate across all days
+        const validRates = metrics
+          .map(m => m.acceptance_rate_by_count)
+          .filter(rate => rate !== null && rate !== undefined && !isNaN(rate))
+
+        const acceptanceRate = validRates.length > 0
+          ? validRates.reduce((sum, rate) => sum + rate, 0) / validRates.length
+          : 0
+
+        // Calculate average active users excluding weekends
+        const weekdayUsers = metrics
+          .filter(m => {
+            const dayOfWeek = new Date(m.day).getDay()
+            return dayOfWeek !== 5 && dayOfWeek !== 6 // Exclude Friday and Saturday
+          })
+          .map(m => m.total_active_users || 0)
+
+        const avgActiveUsers = weekdayUsers.length > 0
+          ? Math.round(weekdayUsers.reduce((sum, users) => sum + users, 0) / weekdayUsers.length)
+          : 0
+
+        return { acceptanceRate, avgActiveUsers }
+      } catch (error) {
+        console.error(`Error loading metrics for team ${team.slug}:`, error)
+        return { acceptanceRate: 0, avgActiveUsers: 0 }
+      }
+    }
+
+    const loadAllTeamsMetrics = async () => {
+      isLoading.value = true
+      try {
+        await loadTeams()
+
+        const teamsData = await Promise.all(
+          availableTeams.value.map(async team => {
+            const { acceptanceRate, avgActiveUsers } = await loadMetricsForTeam(team)
+            return {
+              ...team,
+              acceptanceRate,
+              avgActiveUsers,
+              rank: 0 // Will be set after sorting
+            }
+          })
+        )
+
+        // Sort by acceptance rate descending and assign ranks
+        teamsData.sort((a, b) => b.acceptanceRate - a.acceptanceRate)
+        teamsData.forEach((team, index) => {
+          team.rank = index + 1
+        })
+
+        teamsWithMetrics.value = teamsData
+      } catch (error) {
+        console.error('Error loading teams metrics:', error)
+      } finally {
+        isLoading.value = false
+      }
+    }
+
+    onMounted(async () => {
+      await loadAllTeamsMetrics()
+    })
+
+    watch(() => props.dateRange, async () => {
+      await loadAllTeamsMetrics()
+    }, { deep: true })
+
+    return {
+      topTeams,
+      teamsWithMetrics,
+      filteredTeams,
+      searchQuery,
+      tableHeaders,
+      isLoading,
+      getAcceptanceRateColor,
+      getTeamDetailUrl
+    }
+  }
+})
+</script>
+
+<style scoped>
+.top-champions-card {
+  background: linear-gradient(135deg, #fafafa 0%, #f5f5f5 100%);
+}
+
+.champion-card {
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.champion-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15) !important;
+}
+
+.champion-rank-1 {
+  border-top: 4px solid #ffa000;
+}
+
+.champion-rank-2 {
+  border-top: 4px solid #bdbdbd;
+}
+
+.champion-rank-3 {
+  border-top: 4px solid #d84315;
+}
+
+.rank-badge {
+  height: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.rank-number {
+  font-size: 32px;
+  font-weight: bold;
+  color: #757575;
+}
+
+.team-name {
+  min-height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.acceptance-rate {
+  margin: 8px 0;
+}
+
+.rate-value {
+  font-size: 28px;
+  font-weight: bold;
+  color: #1976d2;
+}
+
+.team-stats {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.stat-item {
+  display: flex;
+  align-items: center;
+}
+
+.team-name-cell {
+  max-width: 300px;
+}
+
+:deep(.v-data-table) {
+  border-radius: 4px;
+}
+
+:deep(.v-data-table__th) {
+  font-weight: 600 !important;
+  background-color: #f5f5f5;
+}
+
+:deep(.v-data-table__tr:hover) {
+  background-color: #fafafa !important;
+}
+</style>

--- a/app/components/MainComponent.vue
+++ b/app/components/MainComponent.vue
@@ -86,6 +86,9 @@ v-if="item === 'copilot chat'" :metrics="metrics"
             <ApiResponse
 v-if="item === 'api response'" :metrics="metrics" :original-metrics="originalMetrics"
               :seats="seats" />
+            <ChampionsViewer
+v-if="item === 'champions'" :date-range="dateRange"
+              :date-range-description="dateRangeDescription" />
           </v-card>
         </v-window-item>
         <v-alert
@@ -112,6 +115,7 @@ import SeatsAnalysisViewer from './SeatsAnalysisViewer.vue'
 import TeamsComponent from './TeamsComponent.vue'
 import ApiResponse from './ApiResponse.vue'
 import AgentModeViewer from './AgentModeViewer.vue'
+import ChampionsViewer from './ChampionsViewer.vue'
 import DateRangeSelector from './DateRangeSelector.vue'
 import { Options } from '@/model/Options';
 import { useRoute } from 'vue-router';
@@ -126,6 +130,7 @@ export default defineNuxtComponent({
     TeamsComponent,
     ApiResponse,
     AgentModeViewer,
+    ChampionsViewer,
     DateRangeSelector
   },
   methods: {
@@ -235,7 +240,7 @@ export default defineNuxtComponent({
 
   data() {
     return {
-      tabItems: ['languages', 'editors', 'copilot chat', 'github.com', 'seat analysis', 'api response'],
+      tabItems: ['languages', 'editors', 'copilot chat', 'github.com', 'seat analysis', 'api response', 'champions'],
       tab: null,
       dateRangeDescription: 'Over the last 28 days',
       isLoading: false,

--- a/app/components/MainComponent.vue
+++ b/app/components/MainComponent.vue
@@ -141,6 +141,8 @@ export default defineNuxtComponent({
         case 'team-organization':
         case 'team-enterprise':
           return 'team';
+        case 'multi-organization':
+          return 'organizations';
         case 'organization':
         case 'enterprise':
           return itemName;
@@ -252,8 +254,8 @@ export default defineNuxtComponent({
   created() {
     this.tabItems.unshift(this.getDisplayTabName(this.itemName));
     
-    // Add teams tab for organization and enterprise scopes to allow team comparison
-    if (this.itemName === 'organization' || this.itemName === 'enterprise') {
+    // Add teams tab for organization, enterprise, and multi-organization scopes to allow team comparison
+    if (this.itemName === 'organization' || this.itemName === 'enterprise' || this.itemName === 'multi-organization') {
       this.tabItems.splice(1, 0, 'teams'); // Insert after the first tab
     }
     

--- a/app/components/TeamsComponent.vue
+++ b/app/components/TeamsComponent.vue
@@ -740,18 +740,18 @@ export default defineComponent({
       })
       aggregatedTotalActiveUsers.value = Math.round(totalActive)
       
-      // Calculate average acceptance rate across all teams
+      // Calculate average acceptance rate across all teams using cumulative totals (same as MetricsViewer)
       let totalAcceptanceRate = 0
       let teamCount = 0
       perTeamData.forEach(teamData => {
         if (teamData.metrics.length) {
-          const validRates = teamData.metrics
-            .map(d => d.acceptance_rate_by_count)
-            .filter(rate => rate !== null && rate !== undefined && !isNaN(rate))
+          // Calculate using cumulative totals for this team
+          const totalSuggestions = teamData.metrics.reduce((sum, m) => sum + (m.total_suggestions_count || 0), 0)
+          const totalAcceptances = teamData.metrics.reduce((sum, m) => sum + (m.total_acceptances_count || 0), 0)
           
-          if (validRates.length > 0) {
-            const teamAvg = validRates.reduce((sum, rate) => sum + rate, 0) / validRates.length
-            totalAcceptanceRate += teamAvg
+          if (totalSuggestions > 0) {
+            const teamRate = (totalAcceptances / totalSuggestions) * 100
+            totalAcceptanceRate += teamRate
             teamCount++
           }
         }

--- a/app/components/TeamsComponent.vue
+++ b/app/components/TeamsComponent.vue
@@ -15,7 +15,7 @@
               <v-row>
                 <v-col cols="12" md="8">
                   <v-autocomplete
-v-model="selectedTeams" :items="availableTeams" item-value="slug" item-title="name"
+v-model="selectedTeams" :items="availableTeams" item-value="uniqueId" item-title="displayName"
                     label="Search and select teams to compare" multiple chips clearable variant="outlined" :menu-props="{
                       contentClass: 'teams-select-menu',
                       maxHeight: 360,
@@ -24,10 +24,10 @@ v-model="selectedTeams" :items="availableTeams" item-value="slug" item-title="na
                       offset: 8
                     }" :hint="`Type to filter and select multiple teams from your ${scopeType} to compare their metrics`" persistent-hint>
                     <template #item="{ props, item }">
-                      <v-list-item v-bind="props" :title="item.raw.name" :subtitle="item.raw.description" />
+                      <v-list-item v-bind="props" :title="item.raw.displayName" :subtitle="item.raw.description" />
                     </template>
                     <template #chip="{ props, item }">
-                      <v-chip v-bind="props" class="select-chip" :text="item.raw.name" closable />
+                      <v-chip v-bind="props" class="select-chip" :text="item.raw.displayName" closable />
                     </template>
                   </v-autocomplete>
                 </v-col>
@@ -54,9 +54,9 @@ v-if="selectedTeams.length > 0" color="primary" variant="outlined" size="small"
             <v-card-text>
               <v-chip-group>
                 <v-chip
-v-for="team in selectedTeamObjects" :key="team.slug" :href="getTeamDetailUrl(team.slug)"
+v-for="team in selectedTeamObjects" :key="team.uniqueId" :href="getTeamDetailUrl(team)"
                   class="selected-team-chip" target="_blank" link>
-                  {{ team.name }} - View Details
+                  {{ team.displayName }} - View Details
                   <v-icon end>mdi-open-in-new</v-icon>
                 </v-chip>
               </v-chip-group>
@@ -320,6 +320,9 @@ interface Team {
   name: string
   slug: string
   description?: string
+  organization?: string // Track which org this team belongs to
+  uniqueId?: string // Unique identifier: org/slug or just slug
+  displayName?: string // Display name with org context if needed
 }
 
 interface LanguageTeamData { team: string; language: string; acceptance_rate: number }
@@ -372,9 +375,10 @@ export default defineComponent({
       elements: { bar: { borderWidth: 1 } }
     }
 
-    const selectedTeamObjects = computed(() => availableTeams.value.filter(team => selectedTeams.value.includes(team.slug)))
+    const selectedTeamObjects = computed(() => availableTeams.value.filter(team => selectedTeams.value.includes(team.uniqueId || team.slug)))
     const scopeType = computed(() => {
       const config = useRuntimeConfig()
+      if (config.public.scope === 'multi-organization') return 'organizations'
       return config.public.scope === 'enterprise' ? 'enterprise' : 'organization'
     })
   // Aggregate total active users across selected teams (latest day for each)
@@ -382,12 +386,18 @@ export default defineComponent({
   const totalActiveUsers = computed(() => aggregatedTotalActiveUsers.value)
 
     const clearSelection = () => { selectedTeams.value = [] }
-    const getTeamDetailUrl = (teamSlug: string) => {
+    const getTeamDetailUrl = (team: Team) => {
       const config = useRuntimeConfig()
-      return config.public.scope === 'enterprise'
-        ? `/enterprises/${config.public.githubEnt}/teams/${teamSlug}`
-        : `/orgs/${config.public.githubOrg}/teams/${teamSlug}`
+      const org = team.organization || config.public.githubOrg
+      const ent = config.public.githubEnt
+      
+      if (config.public.scope === 'enterprise' || config.public.scope === 'team-enterprise') {
+        return `/enterprises/${ent}/teams/${team.slug}`
+      }
+      return `/orgs/${org}/teams/${team.slug}`
     }
+
+    const getTeamName = (uniqueId: string) => availableTeams.value.find(t => t.uniqueId === uniqueId)?.displayName || uniqueId
 
 
     const loadTeams = async () => {
@@ -396,16 +406,41 @@ export default defineComponent({
       const params = options.toParams();
 
       const teams = await $fetch<Team[]>('/api/teams', { params })
-      availableTeams.value = teams
+      
+      // Add uniqueId and displayName to each team
+      const config = useRuntimeConfig()
+      const isMultiOrg = config.public.scope === 'multi-organization'
+      
+      availableTeams.value = teams.map(team => ({
+        ...team,
+        uniqueId: team.organization ? `${team.organization}/${team.slug}` : team.slug,
+        displayName: team.organization && isMultiOrg ? `${team.name} (${team.organization})` : team.name
+      }))
     }
     // Load metrics for a single team via /api/metrics (old + new formats)
-    const loadMetricsForTeam = async (teamSlug: string) => {
+    const loadMetricsForTeam = async (teamUniqueId: string) => {
       const route = useRoute();
       const options = Options.fromRoute(route, props.dateRange.since, props.dateRange.until);
+      
+      // Find the team by uniqueId
+      const teamObj = availableTeams.value.find(t => t.uniqueId === teamUniqueId);
+      if (!teamObj) return { metrics: [], usage: [] };
+      
       // Force scope to team variant based on current broader scope
-      if (options.scope === 'enterprise') options.scope = 'team-enterprise';
-      else if (options.scope === 'organization') options.scope = 'team-organization';
-      options.githubTeam = teamSlug;
+      if (options.scope === 'enterprise') {
+        options.scope = 'team-enterprise';
+      } else if (options.scope === 'organization' || options.scope === 'multi-organization') {
+        options.scope = 'team-organization';
+        // For multi-organization, use the team's organization if available
+        if (teamObj.organization) {
+          options.githubOrg = teamObj.organization;
+        } else if (options.githubOrgs && options.githubOrgs.length > 0) {
+          // Fallback to first org if organization not tracked
+          options.githubOrg = options.githubOrgs[0];
+        }
+      }
+      
+      options.githubTeam = teamObj.slug;
       const params = options.toParams();
       const response = await $fetch<MetricsApiResponse>('/api/metrics', { params })
       return response;
@@ -414,14 +449,15 @@ export default defineComponent({
     const generateBarChartData = () => {
       // Generate language bar chart data
       const languages = [...new Set(languageComparison.value.map(l => l.language))]
-      const teams = [...new Set(languageComparison.value.map(l => l.team))]
+      const teamUniqueIds = [...new Set(languageComparison.value.map(l => l.team))]
 
-      const languageDatasets = teams.map((team, index) => {
+      const languageDatasets = teamUniqueIds.map((uniqueId, index) => {
+        const teamName = getTeamName(uniqueId)
         const colorIndex = index % teamColors.length
         return {
-          label: team,
+          label: teamName,
           data: languages.map(language => {
-            const langData = languageComparison.value.find(l => l.language === language && l.team === team)
+            const langData = languageComparison.value.find(l => l.language === language && l.team === uniqueId)
             return langData ? langData.acceptance_rate : 0
           }),
           backgroundColor: teamColors[colorIndex]!.border,
@@ -438,12 +474,13 @@ export default defineComponent({
       // Generate editor bar chart data
       const editors = [...new Set(editorComparison.value.map(e => e.editor))]
 
-      const editorDatasets = teams.map((team, index) => {
+      const editorDatasets = teamUniqueIds.map((uniqueId, index) => {
+        const teamName = getTeamName(uniqueId)
         const colorIndex = index % teamColors.length
         return {
-          label: team,
+          label: teamName,
           data: editors.map(editor => {
-            const editorData = editorComparison.value.find(e => e.editor === editor && e.team === team)
+            const editorData = editorComparison.value.find(e => e.editor === editor && e.team === uniqueId)
             return editorData ? editorData.active_users : 0
           }),
           backgroundColor: teamColors[colorIndex]!.border,
@@ -487,12 +524,12 @@ export default defineComponent({
       }
 
       // Fetch metrics for each selected team individually
-      const perTeamResponses = await Promise.all(selectedTeams.value.map(slug => loadMetricsForTeam(slug)))
+      const perTeamResponses = await Promise.all(selectedTeams.value.map(uniqueId => loadMetricsForTeam(uniqueId)))
 
       // Build a structure for quick lookup
-      interface PerTeamData { slug: string; metrics: Metrics[]; usage: CopilotMetrics[] }
+      interface PerTeamData { uniqueId: string; metrics: Metrics[]; usage: CopilotMetrics[] }
       const perTeamData: PerTeamData[] = perTeamResponses.map((resp, idx) => ({
-        slug: selectedTeams.value[idx]!,
+        uniqueId: selectedTeams.value[idx]!,
         metrics: (resp.metrics as Metrics[]) || [],
         usage: (resp.usage as CopilotMetrics[]) || []
       }))
@@ -504,12 +541,10 @@ export default defineComponent({
   perTeamData.forEach(t => t.usage.forEach((u) => { if (u.date) daySet.add(u.date) }))
       const days = Array.from(daySet).sort()
 
-      const getTeamName = (slug: string) => availableTeams.value.find(t => t.slug === slug)?.name || slug
-
       // Helper to create line datasets pulling from Metrics objects
       const createMetricsDatasets = (metricKey: LineMetricKey, label: string): ChartDataset<'line', number[]>[] => {
         return perTeamData.map((teamData, index) => {
-          const teamName = getTeamName(teamData.slug)
+          const teamName = getTeamName(teamData.uniqueId)
           const colorIndex = index % teamColors.length
           return {
             label: `${teamName} - ${label}`,
@@ -532,7 +567,7 @@ export default defineComponent({
       // Suggestions & Acceptances datasets
       const suggestionsDatasets: ChartDataset<'line', number[]>[] = []
       perTeamData.forEach((teamData, index) => {
-        const teamName = getTeamName(teamData.slug)
+        const teamName = getTeamName(teamData.uniqueId)
         const colorIndex = index % teamColors.length
         const suggestionsDataset: ChartDataset<'line', number[]> = {
           label: `${teamName} - Suggestions`,
@@ -567,7 +602,7 @@ export default defineComponent({
       // Lines suggested & accepted
       const linesDatasets: ChartDataset<'line', number[]>[] = []
       perTeamData.forEach((teamData, index) => {
-        const teamName = getTeamName(teamData.slug)
+        const teamName = getTeamName(teamData.uniqueId)
         const colorIndex = index % teamColors.length
         linesDatasets.push(
           {
@@ -603,7 +638,7 @@ export default defineComponent({
       // Feature usage charts derived from NEW usage format (CopilotMetrics)
       const createUsageDataset = (path: string[], label: string): ChartDataset<'line', number[]>[] => {
         return perTeamData.map((teamData, index) => {
-          const teamName = getTeamName(teamData.slug)
+          const teamName = getTeamName(teamData.uniqueId)
             const colorIndex = index % teamColors.length
             return {
               label: `${teamName} - ${label}`,
@@ -651,10 +686,10 @@ export default defineComponent({
         })
         Object.entries(langAgg).forEach(([language, vals]) => {
           const rate = vals.suggestions ? (vals.acceptances / vals.suggestions) * 100 : 0
-          langComp.push({ team: teamData.slug, language, acceptance_rate: rate })
+          langComp.push({ team: teamData.uniqueId, language, acceptance_rate: rate })
         })
         Object.entries(editorAgg).forEach(([editor, active]) => {
-          editorComp.push({ team: teamData.slug, editor, active_users: active })
+          editorComp.push({ team: teamData.uniqueId, editor, active_users: active })
         })
       })
       languageComparison.value = langComp

--- a/app/model/Options.ts
+++ b/app/model/Options.ts
@@ -110,12 +110,16 @@ export class Options {
         } else {
             // Use defaults from runtime config
             options.scope = (config.public.scope as Scope) || 'organization';
-            if (config.public.githubOrg) options.githubOrg = config.public.githubOrg;
-            if (config.public.githubOrgs) {
-                // Parse comma-separated list of organizations
-                options.githubOrgs = config.public.githubOrgs.split(',').map(org => org.trim()).filter(Boolean);
-                if (options.githubOrgs.length > 1) {
+            if (config.public.githubOrg) {
+                // Check if githubOrg contains comma-separated list
+                const orgs = config.public.githubOrg.split(',').map(org => org.trim()).filter(Boolean);
+                if (orgs.length > 1) {
+                    // Multi-organization mode
+                    options.githubOrgs = orgs;
                     options.scope = 'multi-organization';
+                } else {
+                    // Single organization
+                    options.githubOrg = orgs[0];
                 }
             }
             if (config.public.githubEnt) options.githubEnt = config.public.githubEnt;

--- a/app/model/Options.ts
+++ b/app/model/Options.ts
@@ -5,13 +5,14 @@
 import type { QueryObject } from 'ufo';
 import type { RouteLocationNormalizedLoadedGeneric } from 'vue-router';
 
-export type Scope = 'organization' | 'enterprise' | 'team-organization' | 'team-enterprise';
+export type Scope = 'organization' | 'enterprise' | 'team-organization' | 'team-enterprise' | 'multi-organization';
 
 export interface OptionsData {
     since?: string;
     until?: string;
     isDataMocked?: boolean;
     githubOrg?: string;
+    githubOrgs?: string[]; // Multiple organizations for multi-org scope
     githubEnt?: string;
     githubTeam?: string;
     scope?: Scope;
@@ -23,6 +24,7 @@ export interface RuntimeConfig {
     public: {
         scope?: string;
         githubOrg?: string;
+        githubOrgs?: string; // Comma-separated list of orgs
         githubEnt?: string;
         githubTeam?: string;
         isDataMocked?: boolean;
@@ -51,6 +53,7 @@ export class Options {
     public until?: string;
     public isDataMocked?: boolean;
     public githubOrg?: string;
+    public githubOrgs?: string[]; // Multiple organizations
     public githubEnt?: string;
     public githubTeam?: string;
     public scope?: Scope;
@@ -62,6 +65,7 @@ export class Options {
         this.until = data.until;
         this.isDataMocked = data.isDataMocked;
         this.githubOrg = data.githubOrg;
+        this.githubOrgs = data.githubOrgs;
         this.githubEnt = data.githubEnt;
         this.githubTeam = data.githubTeam;
         this.scope = data.scope;
@@ -107,6 +111,13 @@ export class Options {
             // Use defaults from runtime config
             options.scope = (config.public.scope as Scope) || 'organization';
             if (config.public.githubOrg) options.githubOrg = config.public.githubOrg;
+            if (config.public.githubOrgs) {
+                // Parse comma-separated list of organizations
+                options.githubOrgs = config.public.githubOrgs.split(',').map(org => org.trim()).filter(Boolean);
+                if (options.githubOrgs.length > 1) {
+                    options.scope = 'multi-organization';
+                }
+            }
             if (config.public.githubEnt) options.githubEnt = config.public.githubEnt;
             if (config.public.githubTeam) options.githubTeam = config.public.githubTeam;
         }
@@ -119,10 +130,12 @@ export class Options {
      * Create Options from URLSearchParams
      */
     static fromURLSearchParams(params: URLSearchParams): Options {
+        const githubOrgsParam = params.get('githubOrgs');
         const options = new Options({
             since: params.get('since') || undefined,
             until: params.get('until') || undefined,
             githubOrg: params.get('githubOrg') || undefined,
+            githubOrgs: githubOrgsParam ? githubOrgsParam.split(',').map(org => org.trim()).filter(Boolean) : undefined,
             githubEnt: params.get('githubEnt') || undefined,
             githubTeam: params.get('githubTeam') || undefined,
             scope: (params.get('scope') as Scope) || undefined,
@@ -142,10 +155,16 @@ export class Options {
     }
 
     static fromQuery(query: QueryObject): Options {
+        const githubOrgsQuery = query.githubOrgs;
+        const githubOrgsArray = typeof githubOrgsQuery === 'string' 
+            ? githubOrgsQuery.split(',').map(org => org.trim()).filter(Boolean)
+            : Array.isArray(githubOrgsQuery) ? githubOrgsQuery : undefined;
+        
         const options = new Options({
             since: query.since as string | undefined,
             until: query.until as string | undefined,
             githubOrg: query.githubOrg as string | undefined,
+            githubOrgs: githubOrgsArray,
             githubEnt: query.githubEnt as string | undefined,
             githubTeam: query.githubTeam as string | undefined,
             scope: (query.scope as Scope) || undefined,
@@ -181,6 +200,7 @@ export class Options {
         if (this.until) params.set('until', this.until);
         if (this.isDataMocked) params.set('isDataMocked', 'true');
         if (this.githubOrg) params.set('githubOrg', this.githubOrg);
+        if (this.githubOrgs && this.githubOrgs.length > 0) params.set('githubOrgs', this.githubOrgs.join(','));
         if (this.githubEnt) params.set('githubEnt', this.githubEnt);
         if (this.githubTeam) params.set('githubTeam', this.githubTeam);
         if (this.scope) params.set('scope', this.scope);
@@ -196,6 +216,7 @@ export class Options {
         if (this.until) params.until = this.until;
         if (this.isDataMocked) params.isDataMocked = String(this.isDataMocked);
         if (this.githubOrg) params.githubOrg = this.githubOrg;
+        if (this.githubOrgs && this.githubOrgs.length > 0) params.githubOrgs = this.githubOrgs.join(',');
         if (this.githubEnt) params.githubEnt = this.githubEnt;
         if (this.githubTeam) params.githubTeam = this.githubTeam;
         if (this.scope) params.scope = this.scope;
@@ -214,6 +235,7 @@ export class Options {
         if (this.until !== undefined) result.until = this.until;
         if (this.isDataMocked !== undefined) result.isDataMocked = this.isDataMocked;
         if (this.githubOrg !== undefined) result.githubOrg = this.githubOrg;
+        if (this.githubOrgs !== undefined) result.githubOrgs = this.githubOrgs;
         if (this.githubEnt !== undefined) result.githubEnt = this.githubEnt;
         if (this.githubTeam !== undefined) result.githubTeam = this.githubTeam;
         if (this.scope !== undefined) result.scope = this.scope;
@@ -239,6 +261,7 @@ export class Options {
             until: other.until ?? this.until,
             isDataMocked: other.isDataMocked ?? this.isDataMocked,
             githubOrg: other.githubOrg ?? this.githubOrg,
+            githubOrgs: other.githubOrgs ?? this.githubOrgs,
             githubEnt: other.githubEnt ?? this.githubEnt,
             githubTeam: other.githubTeam ?? this.githubTeam,
             scope: other.scope ?? this.scope,
@@ -258,13 +281,14 @@ export class Options {
      * Check if GitHub organization/enterprise settings are configured
      */
     hasGitHubConfig(): boolean {
-        return Boolean(this.githubOrg || this.githubEnt);
+        return Boolean(this.githubOrg || this.githubOrgs?.length || this.githubEnt);
     }
 
     /**
-     * Get the API URL based on scope and configuration
+     * Get the API URL(s) based on scope and configuration
+     * Returns an array for multi-organization scope, single string otherwise
      */
-    getApiUrl(): string {
+    getApiUrl(): string | string[] {
         const baseUrl = 'https://api.github.com';
         let url = '';
 
@@ -297,6 +321,23 @@ export class Options {
                 url = `${baseUrl}/enterprises/${this.githubEnt}/copilot/metrics`;
                 break
 
+            case 'multi-organization':
+                if (!this.githubOrgs || this.githubOrgs.length === 0) {
+                    throw new Error('GitHub organizations must be set for multi-organization scope');
+                }
+                // Return array of URLs for each organization
+                const urls = this.githubOrgs.map(org => {
+                    let orgUrl = `${baseUrl}/orgs/${org}/copilot/metrics`;
+                    if (this.since || this.until) {
+                        const sinceParam = this.since ? `since=${encodeURIComponent(this.since)}` : '';
+                        const untilParam = this.until ? `until=${encodeURIComponent(this.until)}` : '';
+                        const params = [sinceParam, untilParam].filter(Boolean).join('&');
+                        orgUrl += params ? `?${params}` : '';
+                    }
+                    return orgUrl;
+                });
+                return urls;
+
             default:
                 throw new Error(`Invalid scope: ${this.scope}`);
         }
@@ -311,9 +352,10 @@ export class Options {
     }
 
     /**
-     * Get the Seats API URL based on scope and configuration
+     * Get the Seats API URL(s) based on scope and configuration
+     * Returns an array for multi-organization scope, single string otherwise
      */
-    getSeatsApiUrl(): string {
+    getSeatsApiUrl(): string | string[] {
         const baseUrl = 'https://api.github.com';
 
         switch (this.scope) {
@@ -331,6 +373,12 @@ export class Options {
                 }
                 return `${baseUrl}/enterprises/${this.githubEnt}/copilot/billing/seats`;
 
+            case 'multi-organization':
+                if (!this.githubOrgs || this.githubOrgs.length === 0) {
+                    throw new Error('GitHub organizations must be set for multi-organization scope');
+                }
+                return this.githubOrgs.map(org => `${baseUrl}/orgs/${org}/copilot/billing/seats`);
+
             default:
                 throw new Error(`Invalid scope: ${this.scope}`);
         }
@@ -338,8 +386,9 @@ export class Options {
     
     /**
      * Get the Teams API URL based on scope and configuration
+     * Returns an array for multi-organization scope, single string otherwise
      */
-    getTeamsApiUrl(): string {
+    getTeamsApiUrl(): string | string[] {
         const baseUrl = 'https://api.github.com';
 
         switch (this.scope) {
@@ -356,6 +405,12 @@ export class Options {
                     throw new Error('GitHub enterprise must be set for enterprise scope');
                 }
                 return `${baseUrl}/enterprises/${this.githubEnt}/teams`;
+
+            case 'multi-organization':
+                if (!this.githubOrgs || this.githubOrgs.length === 0) {
+                    throw new Error('GitHub organizations must be set for multi-organization scope');
+                }
+                return this.githubOrgs.map(org => `${baseUrl}/orgs/${org}/teams`);
 
             default:
                 throw new Error(`Invalid scope: ${this.scope}`);
@@ -440,6 +495,14 @@ export class Options {
         if (this.scope === 'organization' || this.scope === 'team-organization') {
             if (!this.githubOrg) {
                 errors.push('GitHub organization must be set for organization scopes');
+            }
+        }
+
+        if (this.scope === 'multi-organization') {
+            if (!this.githubOrgs || this.githubOrgs.length === 0) {
+                errors.push('GitHub organizations must be set for multi-organization scope');
+            } else if (this.githubOrgs.length < 2) {
+                errors.push('At least two organizations must be specified for multi-organization scope');
             }
         }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -91,8 +91,7 @@ export default defineNuxtConfig({
     public: {
       isDataMocked: false,  // can be overridden by NUXT_PUBLIC_IS_DATA_MOCKED environment variable
       scope: 'organization',  // can be overridden by NUXT_PUBLIC_SCOPE environment variable
-      githubOrg: '',
-      githubOrgs: '',  // comma-separated list of organizations for multi-org scope
+      githubOrg: '',  // can be a single org or comma-separated list for multi-org
       githubEnt: '',
       githubTeam: '',
       usingGithubAuth: false,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -92,6 +92,7 @@ export default defineNuxtConfig({
       isDataMocked: false,  // can be overridden by NUXT_PUBLIC_IS_DATA_MOCKED environment variable
       scope: 'organization',  // can be overridden by NUXT_PUBLIC_SCOPE environment variable
       githubOrg: '',
+      githubOrgs: '',  // comma-separated list of organizations for multi-org scope
       githubEnt: '',
       githubTeam: '',
       usingGithubAuth: false,

--- a/server/api/github-stats.ts
+++ b/server/api/github-stats.ts
@@ -58,6 +58,13 @@ function calculateGitHubStats(metrics: CopilotMetrics[]): GitHubStats {
     totalPRSummariesCreated: 0
   });
 
+  // Calculate averages for user counts (divide by number of days with data)
+  const daysCount = metrics.length || 1;
+  totals.totalIdeCodeCompletionUsers = Math.round(totals.totalIdeCodeCompletionUsers / daysCount);
+  totals.totalIdeChatUsers = Math.round(totals.totalIdeChatUsers / daysCount);
+  totals.totalDotcomChatUsers = Math.round(totals.totalDotcomChatUsers / daysCount);
+  totals.totalDotcomPRUsers = Math.round(totals.totalDotcomPRUsers / daysCount);
+
   // Calculate unique models with optimized approach
   const modelSets = {
     ideCodeCompletion: new Set<string>(),
@@ -156,6 +163,23 @@ function calculateGitHubStats(metrics: CopilotMetrics[]): GitHubStats {
       });
     });
   }
+
+  // Convert summed user counts to averages for model details
+  modelMaps.ideCodeCompletion.forEach((value) => {
+    value.total_engaged_users = Math.round(value.total_engaged_users / daysCount);
+  });
+
+  modelMaps.ideChat.forEach((value) => {
+    value.total_engaged_users = Math.round(value.total_engaged_users / daysCount);
+  });
+
+  modelMaps.dotcomChat.forEach((value) => {
+    value.total_engaged_users = Math.round(value.total_engaged_users / daysCount);
+  });
+
+  modelMaps.dotcomPR.forEach((value) => {
+    value.total_engaged_users = Math.round(value.total_engaged_users / daysCount);
+  });
 
   // Chart data
   const labels = metrics.map(metric => metric.date);

--- a/shared/utils/getDisplayName.ts
+++ b/shared/utils/getDisplayName.ts
@@ -1,5 +1,13 @@
-export default function getDisplayName(input: { githubOrg: string; githubEnt: string; githubTeam: string; scope: string }) {
+export default function getDisplayName(input: { githubOrg: string; githubOrgs: string; githubEnt: string; githubTeam: string; scope: string }) {
     const teamName = input.githubTeam && input.githubTeam.trim() !== '' ? `| Team : ${input.githubTeam}` : '';
+    
+    // Handle multi-organization scope
+    if (input.scope === 'multi-organization' && input.githubOrgs) {
+        const orgsArray = input.githubOrgs.split(',').map(org => org.trim()).filter(Boolean);
+        const orgsList = orgsArray.join(', ');
+        return `Copilot Metrics Viewer | Organizations : ${orgsList}`;
+    }
+    
     const topLevelScope = input.githubEnt ? 'Enterprise' : 'Organization';
 
     return `Copilot Metrics Viewer | ${topLevelScope} : ${input.githubOrg || input.githubEnt} ${teamName}`;

--- a/shared/utils/getDisplayName.ts
+++ b/shared/utils/getDisplayName.ts
@@ -1,9 +1,9 @@
-export default function getDisplayName(input: { githubOrg: string; githubOrgs: string; githubEnt: string; githubTeam: string; scope: string }) {
+export default function getDisplayName(input: { githubOrg: string; githubEnt: string; githubTeam: string; scope: string }) {
     const teamName = input.githubTeam && input.githubTeam.trim() !== '' ? `| Team : ${input.githubTeam}` : '';
     
     // Handle multi-organization scope
-    if (input.scope === 'multi-organization' && input.githubOrgs) {
-        const orgsArray = input.githubOrgs.split(',').map(org => org.trim()).filter(Boolean);
+    if (input.scope === 'multi-organization' && input.githubOrg) {
+        const orgsArray = input.githubOrg.split(',').map(org => org.trim()).filter(Boolean);
         const orgsList = orgsArray.join(', ');
         return `Copilot Metrics Viewer | Organizations : ${orgsList}`;
     }

--- a/shared/utils/metrics-util.ts
+++ b/shared/utils/metrics-util.ts
@@ -262,8 +262,13 @@ function aggregateMetricsByDate(metrics: CopilotMetrics[]): CopilotMetrics[] {
       // Aggregate with existing metric for this date
       const existing = aggregated.get(date)!;
       
-      // Sum total_active_users
-      existing.total_active_users = (existing.total_active_users || 0) + (metric.total_active_users || 0);
+      // IMPORTANT: For total_active_users in multi-org scenarios, we take the MAX instead of SUM
+      // because users may be counted in multiple organizations (would cause double-counting)
+      // This gives us a conservative estimate of unique active users
+      existing.total_active_users = Math.max(
+        existing.total_active_users || 0, 
+        metric.total_active_users || 0
+      );
       
       // Merge copilot_ide_code_completions
       if (metric.copilot_ide_code_completions) {


### PR DESCRIPTION
This PR introduces support for aggregating GitHub Copilot metrics across multiple organizations, enabling unified visibility and analysis of Copilot usage for teams working across organizational boundaries.

🆕 New Features
Multi-Organization Scope: Added new multi-organization scope type to fetch and aggregate metrics from multiple GitHub organizations simultaneously
Environment Configuration: Introduced NUXT_PUBLIC_GITHUB_ORGS environment variable for comma-separated organization list configuration
Parallel Data Fetching: Implemented concurrent API calls to multiple organizations with intelligent caching per organization

📊 Data Aggregation & Deduplication
Metrics Aggregation: Created aggregateMetricsByDate() function to merge metrics across organizations by date
Smart User Counting: Uses MAX aggregation for total_active_users instead of SUM to prevent double-counting users who are active in multiple organizations
Seats Deduplication: Implemented deduplicateSeats() to merge seat assignments across organizations, keeping the most recent activity per user
Teams Organization Tracking: Extended team data to track which organization each team belongs to, enabling proper team comparisons across orgs

Example configuration: 
<img width="354" height="58" alt="image" src="https://github.com/user-attachments/assets/884b4947-dd15-42d5-9d19-1856ae4c1a99" />

Technical Highlights
Maintains backward compatibility with existing single-organization scope
Preserves per-organization caching for optimal performance
Conservative user counting approach (MAX vs SUM) ensures accurate metrics without inflation
Fully type-safe TypeScript implementation with updated serialization methods