### PR TITLE
Fix chronological ordering for date-based metrics charts

### DIFF
--- a/server/api/metrics.ts
+++ b/server/api/metrics.ts
@@ -2,6 +2,10 @@ import { convertToMetrics } from '@/model/MetricsToUsageConverter';
 import type { MetricsApiResponse } from "@/types/metricsApiResponse";
 import { getMetricsDataV2 } from '../../shared/utils/metrics-util-v2';
 
+function sortMetricsByDay<T extends { day: string }>(metrics: T[]): T[] {
+    return [...metrics].sort((left, right) => left.day.localeCompare(right.day));
+}
+
 export default defineEventHandler(async (event) => {
 
     const logger = console;
@@ -11,7 +15,7 @@ export default defineEventHandler(async (event) => {
         const { metrics: usageData, reportData } = await getMetricsDataV2(event);
 
         // metrics is the old API format
-        const metricsData = convertToMetrics(usageData);
+        const metricsData = sortMetricsByDay(convertToMetrics(usageData));
 
         const result = { metrics: metricsData, usage: usageData, reportData } as MetricsApiResponse;
         return result;

--- a/server/services/report-transformer.ts
+++ b/server/services/report-transformer.ts
@@ -21,11 +21,19 @@ const CHAT_FEATURES = [
   'chat_panel_custom_mode', 'chat_panel_unknown_mode', 'chat_inline',
 ];
 
+export function sortReportDayTotalsByDay(dayTotals: ReportDayTotals[]): ReportDayTotals[] {
+  return [...dayTotals].sort((left, right) => left.day.localeCompare(right.day));
+}
+
+export function sortCopilotMetricsByDate(metrics: CopilotMetrics[]): CopilotMetrics[] {
+  return [...metrics].sort((left, right) => left.date.localeCompare(right.date));
+}
+
 /**
  * Transform an entire OrgReport into an array of CopilotMetrics records.
  */
 export function transformReportToMetrics(report: OrgReport): CopilotMetrics[] {
-  return report.day_totals.map(transformDayToMetrics);
+  return sortReportDayTotalsByDay(report.day_totals).map(transformDayToMetrics);
 }
 
 /**

--- a/shared/utils/metrics-util-v2.ts
+++ b/shared/utils/metrics-util-v2.ts
@@ -18,12 +18,23 @@ import { filterHolidaysFromMetrics } from '@/utils/dateUtils';
 import { getMetricsData as getLegacyMetricsData } from './metrics-util';
 import { getMetricsByDateRange, getReportDataByDateRange, saveMetrics } from '../../server/storage/metrics-storage';
 import { fetchLatestReport, type MetricsReportRequest } from '../../server/services/github-copilot-usage-api';
-import { transformReportToMetrics } from '../../server/services/report-transformer';
+import {
+  sortCopilotMetricsByDate,
+  sortReportDayTotalsByDay,
+  transformReportToMetrics,
+} from '../../server/services/report-transformer';
 import { isMockMode } from '../../server/services/github-copilot-usage-api-mock';
 
 export interface MetricsDataResult {
   metrics: CopilotMetrics[];
   reportData: ReportDayTotals[];
+}
+
+function sortMetricsDataResult(result: MetricsDataResult): MetricsDataResult {
+  return {
+    metrics: sortCopilotMetricsByDate(result.metrics),
+    reportData: sortReportDayTotalsByDay(result.reportData),
+  };
 }
 
 /**
@@ -77,7 +88,7 @@ async function fetchFromNewApi(
     });
   }
 
-  return { metrics, reportData };
+  return sortMetricsDataResult({ metrics, reportData });
 }
 
 /**
@@ -106,7 +117,7 @@ export async function getMetricsDataV2(event: H3Event<EventHandlerRequest>): Pro
     if (isLegacyMode()) {
       logger.info('Using mocked data mode (legacy format — USE_LEGACY_API=true)');
       const metrics = await getLegacyMetricsData(event);
-      return { metrics, reportData: [] };
+      return sortMetricsDataResult({ metrics, reportData: [] });
     }
     // Default: exercise full new-API mock pipeline
     logger.info('Using mocked data mode (new API format via HTTP download)');
@@ -114,7 +125,7 @@ export async function getMetricsDataV2(event: H3Event<EventHandlerRequest>): Pro
     const scope = (options.scope || 'organization') as MetricsReportRequest['scope'];
     const report = await fetchLatestReport({ scope, identifier }, new Headers());
     const metrics = transformReportToMetrics(report);
-    return { metrics, reportData: report.day_totals };
+    return sortMetricsDataResult({ metrics, reportData: report.day_totals });
   }
 
   const identifier = options.githubOrg || options.githubEnt || '';
@@ -146,7 +157,7 @@ export async function getMetricsDataV2(event: H3Event<EventHandlerRequest>): Pro
           options.excludeHolidays || false,
           options.locale
         );
-        return { metrics: filteredMetrics, reportData };
+        return sortMetricsDataResult({ metrics: filteredMetrics, reportData });
       }
 
       // DB empty — sync on miss: fetch from API, store, return
@@ -165,7 +176,7 @@ export async function getMetricsDataV2(event: H3Event<EventHandlerRequest>): Pro
         options.excludeHolidays || false,
         options.locale
       );
-      return { metrics: filteredMetrics, reportData: result.reportData };
+      return sortMetricsDataResult({ metrics: filteredMetrics, reportData: result.reportData });
     } catch (error) {
       // If it's already an H3 error (like 401), re-throw
       if (error && typeof error === 'object' && 'statusCode' in error) throw error;
@@ -189,15 +200,18 @@ export async function getMetricsDataV2(event: H3Event<EventHandlerRequest>): Pro
   if (isLegacyMode()) {
     logger.info('Using legacy Copilot Metrics API (USE_LEGACY_API=true, direct, no DB)');
     const metrics = await getLegacyMetricsData(event);
-    return { metrics: filterHolidaysFromMetrics(metrics, options.excludeHolidays || false, options.locale), reportData: [] };
+    return sortMetricsDataResult({
+      metrics: filterHolidaysFromMetrics(metrics, options.excludeHolidays || false, options.locale),
+      reportData: []
+    });
   }
 
   logger.info('Using new Copilot Metrics API (direct, no DB)');
   const result = await fetchFromNewApi(options, event.context.headers);
-  return {
+  return sortMetricsDataResult({
     metrics: filterHolidaysFromMetrics(result.metrics, options.excludeHolidays || false, options.locale),
     reportData: result.reportData
-  };
+  });
 }
 
 /**
@@ -254,5 +268,5 @@ async function fetchAndStore(
     });
   }
 
-  return { metrics, reportData };
+  return sortMetricsDataResult({ metrics, reportData });
 }

--- a/tests/api-migration-integration.spec.ts
+++ b/tests/api-migration-integration.spec.ts
@@ -30,6 +30,19 @@ describe('API Migration Integration', () => {
       expect(completions?.languages?.length).toBeGreaterThan(0);
     });
 
+    it('should sort transformed metrics chronologically when report day_totals are out of order', () => {
+      const report = generateMockReport('2026-02-20', '2026-02-22');
+      report.day_totals = [report.day_totals[2], report.day_totals[0], report.day_totals[1]];
+
+      const metrics = transformReportToMetrics(report);
+
+      expect(metrics.map(metric => metric.date)).toEqual([
+        '2026-02-20',
+        '2026-02-21',
+        '2026-02-22'
+      ]);
+    });
+
     it('should handle NDJSON parsing (backward compat)', () => {
       const ndjson = '{"date":"2026-02-20","total_active_users":100}\n{"date":"2026-02-21","total_active_users":110}';
       const parsed = parseNDJSON(ndjson);


### PR DESCRIPTION
## Summary
This PR fixes the date ordering bug affecting time-series charts across the metrics dashboard.

The root cause was that daily metrics and report data could be returned in a non-chronological order, and multiple chart components consumed that order directly.

Closes #328.

## Changes
- sort transformed Copilot metrics by date in the shared report transformation flow
- sort report day totals before returning them from shared metrics data utilities
- sort the final `metrics` API response by `day` before it is sent to the frontend
- add a regression test covering out-of-order `day_totals` input

## Validation
- verified locally that `GET /api/metrics` now returns `metrics[].day` in ascending chronological order
- ran full unit test suite: 221 tests passed
- ran production build successfully

## Notes
This keeps the fix at the shared data layer so all downstream charts benefit, rather than patching individual components.