### PR TITLE
refactor: extract shared proxy agent initialization utility

### DIFF
--- a/server/plugins/http-agent.ts
+++ b/server/plugins/http-agent.ts
@@ -1,24 +1,10 @@
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { ofetch } from 'ofetch';
-import { readFileSync } from 'fs';
+import { initializeProxyAgent } from '../utils/proxy-agent';
 
 export default defineNitroPlugin((nitro) => {
-  if (process.env.HTTP_PROXY) {
-    const tlsOptions = process.env.CUSTOM_CA_PATH ? {
-      tls: {
-        ca: [
-          readFileSync(process.env.CUSTOM_CA_PATH)
-        ]
-      }
-    } : {};
+  const proxyAgent = initializeProxyAgent();
 
-    const proxyAgent = new ProxyAgent({
-      uri: process.env.HTTP_PROXY,
-      ...tlsOptions
-    });
-    
-    setGlobalDispatcher(proxyAgent);
-    
+  if (proxyAgent) {
     const fetchWithProxy = ofetch.create({
       dispatcher: proxyAgent,
       httpsProxy: process.env.HTTP_PROXY,

--- a/server/sync-entry.ts
+++ b/server/sync-entry.ts
@@ -16,31 +16,9 @@
  *   - CUSTOM_CA_PATH: Optional path to a custom CA certificate file
  */
 
-// Initialize proxy agent before any fetch calls (mirrors server/plugins/http-agent.ts)
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
-import { readFileSync, existsSync } from 'fs';
-
-if (process.env.HTTP_PROXY) {
-  try {
-    const tlsOptions = process.env.CUSTOM_CA_PATH ? (() => {
-      if (!existsSync(process.env.CUSTOM_CA_PATH!)) {
-        throw new Error(`CUSTOM_CA_PATH file not found: ${process.env.CUSTOM_CA_PATH}`);
-      }
-      return { tls: { ca: [readFileSync(process.env.CUSTOM_CA_PATH!)] } };
-    })() : {};
-
-    const proxyAgent = new ProxyAgent({
-      uri: process.env.HTTP_PROXY,
-      ...tlsOptions
-    });
-
-    setGlobalDispatcher(proxyAgent);
-    console.info(`Proxy agent initialized: ${process.env.HTTP_PROXY}`);
-  } catch (error) {
-    console.error('Failed to initialize proxy agent:', error);
-    process.exit(1);
-  }
-}
+// Initialize proxy agent before any fetch calls
+import { initializeProxyAgent } from './utils/proxy-agent';
+initializeProxyAgent(true /* exitOnError */);
 
 import { syncBulk } from './services/sync-service';
 import { initSchema } from './storage/db';

--- a/server/utils/proxy-agent.ts
+++ b/server/utils/proxy-agent.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared proxy agent initialization utility.
+ *
+ * Used by:
+ *   - server/plugins/http-agent.ts  (Nitro web app)
+ *   - server/sync-entry.ts          (standalone sync container)
+ *
+ * Environment variables:
+ *   - HTTP_PROXY:      Optional HTTP/HTTPS proxy URL (e.g. http://proxy:8080)
+ *   - CUSTOM_CA_PATH:  Optional path to a custom CA certificate file
+ */
+
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { readFileSync, existsSync } from 'fs';
+
+/**
+ * Initializes a ProxyAgent from environment variables and sets it as the
+ * global undici dispatcher so all `$fetch`/`ofetch` calls use the proxy.
+ *
+ * Returns the created ProxyAgent so callers can wire it into ofetch hooks,
+ * or null if HTTP_PROXY is not set.
+ *
+ * Throws (and exits with code 1 when `exitOnError` is true) if proxy
+ * initialization fails — e.g. missing CA file or invalid proxy URL.
+ */
+export function initializeProxyAgent(exitOnError = false): ProxyAgent | null {
+  if (!process.env.HTTP_PROXY) return null;
+
+  try {
+    let tlsOptions: { tls?: { ca: Buffer[] } } = {};
+
+    if (process.env.CUSTOM_CA_PATH) {
+      if (!existsSync(process.env.CUSTOM_CA_PATH)) {
+        throw new Error(`CUSTOM_CA_PATH file not found: ${process.env.CUSTOM_CA_PATH}`);
+      }
+      tlsOptions = { tls: { ca: [readFileSync(process.env.CUSTOM_CA_PATH)] } };
+    }
+
+    const proxyAgent = new ProxyAgent({
+      uri: process.env.HTTP_PROXY,
+      ...tlsOptions
+    });
+
+    setGlobalDispatcher(proxyAgent);
+    console.info(`[proxy-agent] Proxy initialized: ${process.env.HTTP_PROXY}`);
+
+    return proxyAgent;
+  } catch (error) {
+    console.error('[proxy-agent] Failed to initialize proxy agent:', error);
+    if (exitOnError) process.exit(1);
+    throw error;
+  }
+}

--- a/tests/proxy-agent.spec.ts
+++ b/tests/proxy-agent.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for server/utils/proxy-agent.ts
+ *
+ * Covers:
+ *   - Returns null when HTTP_PROXY is not set
+ *   - Creates and returns a ProxyAgent when HTTP_PROXY is set
+ *   - Calls setGlobalDispatcher with the created agent
+ *   - Reads CA certificate when CUSTOM_CA_PATH is set and file exists
+ *   - Throws (and optionally calls process.exit) when CUSTOM_CA_PATH file is missing
+ *   - exitOnError=false rethrows instead of calling process.exit
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// --- Mocks ---
+
+const mockSetGlobalDispatcher = vi.fn();
+const mockProxyAgentInstance = { uri: '' };
+const MockProxyAgent = vi.fn((opts: { uri: string }) => {
+  mockProxyAgentInstance.uri = opts.uri;
+  return mockProxyAgentInstance;
+});
+
+vi.mock('undici', () => ({
+  ProxyAgent: MockProxyAgent,
+  setGlobalDispatcher: mockSetGlobalDispatcher,
+}));
+
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+
+vi.mock('fs', () => ({
+  default: { existsSync: mockExistsSync, readFileSync: mockReadFileSync },
+  existsSync: mockExistsSync,
+  readFileSync: mockReadFileSync,
+}));
+
+// Import AFTER mocks are registered
+const { initializeProxyAgent } = await import('../server/utils/proxy-agent');
+
+describe('initializeProxyAgent', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns null when HTTP_PROXY is not set', () => {
+    delete process.env.HTTP_PROXY;
+    const result = initializeProxyAgent();
+    expect(result).toBeNull();
+    expect(MockProxyAgent).not.toHaveBeenCalled();
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('creates a ProxyAgent and sets global dispatcher when HTTP_PROXY is set', () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+    delete process.env.CUSTOM_CA_PATH;
+
+    const result = initializeProxyAgent();
+
+    expect(MockProxyAgent).toHaveBeenCalledOnce();
+    expect(MockProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ uri: 'http://proxy.example.com:8080' })
+    );
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledOnce();
+    expect(mockSetGlobalDispatcher).toHaveBeenCalledWith(mockProxyAgentInstance);
+    expect(result).toBe(mockProxyAgentInstance);
+  });
+
+  it('reads the CA file and passes tls options when CUSTOM_CA_PATH is set and file exists', () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+    process.env.CUSTOM_CA_PATH = '/certs/custom-ca.crt';
+    const fakeBuffer = Buffer.from('cert-data');
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(fakeBuffer);
+
+    const result = initializeProxyAgent();
+
+    expect(mockExistsSync).toHaveBeenCalledWith('/certs/custom-ca.crt');
+    expect(mockReadFileSync).toHaveBeenCalledWith('/certs/custom-ca.crt');
+    expect(MockProxyAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        uri: 'http://proxy.example.com:8080',
+        tls: { ca: [fakeBuffer] },
+      })
+    );
+    expect(result).toBe(mockProxyAgentInstance);
+  });
+
+  it('throws an error when CUSTOM_CA_PATH is set but the file does not exist (exitOnError=false)', () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+    process.env.CUSTOM_CA_PATH = '/certs/missing-ca.crt';
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() => initializeProxyAgent(false)).toThrowError(
+      'CUSTOM_CA_PATH file not found: /certs/missing-ca.crt'
+    );
+    expect(mockSetGlobalDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('calls process.exit(1) when initialization fails and exitOnError=true', () => {
+    process.env.HTTP_PROXY = 'http://proxy.example.com:8080';
+    process.env.CUSTOM_CA_PATH = '/certs/missing-ca.crt';
+    mockExistsSync.mockReturnValue(false);
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never);
+
+    // process.exit is mocked as a no-op so the throw still propagates in tests;
+    // what matters is that exit was called before the rethrow.
+    expect(() => initializeProxyAgent(true)).toThrowError(
+      'CUSTOM_CA_PATH file not found: /certs/missing-ca.crt'
+    );
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/tests/proxy-agent.spec.ts
+++ b/tests/proxy-agent.spec.ts
@@ -109,13 +109,12 @@ describe('initializeProxyAgent', () => {
     process.env.CUSTOM_CA_PATH = '/certs/missing-ca.crt';
     mockExistsSync.mockReturnValue(false);
 
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => {}) as () => never);
-
-    // process.exit is mocked as a no-op so the throw still propagates in tests;
-    // what matters is that exit was called before the rethrow.
-    expect(() => initializeProxyAgent(true)).toThrowError(
-      'CUSTOM_CA_PATH file not found: /certs/missing-ca.crt'
+    // Throw a sentinel so execution stops after process.exit — matching real process termination.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(
+      (() => { throw new Error('process.exit called'); }) as () => never
     );
+
+    expect(() => initializeProxyAgent(true)).toThrowError('process.exit called');
     expect(exitSpy).toHaveBeenCalledWith(1);
 
     exitSpy.mockRestore();


### PR DESCRIPTION
## Summary

Extracts the duplicated proxy initialization logic from `server/plugins/http-agent.ts` and `server/sync-entry.ts` (added in #347) into a single shared utility: `server/utils/proxy-agent.ts`.

## Changes

- **`server/utils/proxy-agent.ts`** _(new)_: `initializeProxyAgent(exitOnError?)` function that:
  - Creates a `ProxyAgent` from `HTTP_PROXY` env var
  - Validates `CUSTOM_CA_PATH` exists before reading (improvement over original `http-agent.ts` which would throw an opaque error)
  - Sets the global undici dispatcher so all `$fetch`/`ofetch` calls use the proxy
  - Returns the `ProxyAgent` instance for callers that need it (e.g. ofetch hook wiring)
  - `exitOnError=true` for CLI use (sync container), `false` for Nitro plugin

- **`server/plugins/http-agent.ts`**: Now delegates to `initializeProxyAgent()` and only handles the Nitro-specific `ofetch` hook wiring

- **`server/sync-entry.ts`**: Proxy setup reduced from 24 lines to 2 lines

## Testing

All 293 unit tests pass.

Follows up on #347.