### PR TITLE
fix(deps): bump @playwright/test to ^1.60.0 to unblock CI on Node 24.16+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ USER node
 ENTRYPOINT [ "/entrypoint.sh" ]
 
 #----------------------------------- PW layer - not used in production
-FROM mcr.microsoft.com/playwright:v1.57.0 AS base-playwright
+FROM mcr.microsoft.com/playwright:v1.60.0-noble AS base-playwright
 
 WORKDIR /pw
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "roboto-fontface": "^0.10.0",
         "undici": ">=7.24.4",
         "unstorage": "^1.17.4",
-        "vue": "*",
+        "vue": "latest",
         "vue-chartjs": "^5.3.2",
         "vuetify": "^3.7.3",
         "webfontloader": "^1.6.28"
@@ -29,7 +29,7 @@
         "@mdi/font": "^7.4.47",
         "@nuxt/fonts": "^0.13.0",
         "@nuxt/test-utils": "^3.20.1",
-        "@playwright/test": "1.57.0",
+        "@playwright/test": "^1.60.0",
         "@types/pg": "^8.18.0",
         "@types/webfontloader": "^1.6.38",
         "@vue/test-utils": "^2.4.6",
@@ -4964,13 +4964,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13804,13 +13804,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13851,9 +13851,9 @@
       }
     },
     "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@mdi/font": "^7.4.47",
     "@nuxt/fonts": "^0.13.0",
     "@nuxt/test-utils": "^3.20.1",
-    "@playwright/test": "1.57.0",
+    "@playwright/test": "^1.60.0",
     "@types/pg": "^8.18.0",
     "@types/webfontloader": "^1.6.38",
     "@vue/test-utils": "^2.4.6",


### PR DESCRIPTION
`npx playwright install` was hanging indefinitely in the Playwright Tests workflow on the current `ubuntu-latest` runner. The job log shows the Chromium download completes, then the process sits silent until the job-level `timeout-minutes` kills it, leaving `npm exec playwright install --with-deps` as an orphan process at cleanup.

Root cause: setup-node `lts/*` now resolves to Node v24.16.0, and Playwright versions < 1.60.0 hit an extract-zip/yauzl regression on Node 24.16+ that causes browser extraction to stall after download (microsoft/playwright#41000, microsoft/playwright#40724). Playwright 1.60.0 ships the fix.

Confirmed unit tests pass locally (457/457).