### PR TITLE
fix: prevent 401 errors and infinite spinner in OAuth mode before login

### DIFF
--- a/app/components/MainComponent.vue
+++ b/app/components/MainComponent.vue
@@ -202,7 +202,7 @@
 
 
     <div v-show="!apiError">
-      <v-progress-linear v-show="!metricsReady" indeterminate color="indigo" />
+      <v-progress-linear v-show="!metricsReady && !signInRequired" indeterminate color="indigo" />
       <v-window v-show="(metricsReady && metrics.length) || (seatsReady && tab === 'seat analysis') || (userMetricsReady && tab === 'user metrics') || (metricsReady && reportData.length > 0 && (tab === 'languages' || tab === 'editors'))" v-model="tab">
         <v-window-item v-for="item in tabItems" :key="item" :value="item">
           <v-card flat>
@@ -342,6 +342,7 @@ export default defineNuxtComponent({
       await this.fetchMetrics();
 
       // Re-fetch user metrics with updated date range
+      if (this.signInRequired) return;
       const { execute: executeUserMetrics, data: userMetricsData, error: userMetricsError } = this.userMetricsFetch;
       await executeUserMetrics();
       if (userMetricsError.value) {


### PR DESCRIPTION
When NUXT_PUBLIC_AUTH_PROVIDERS is set, the DateRangeSelector emits a default range on mount, triggering handleDateRangeChange() before the user is authenticated. This caused an unauthenticated /api/user-metrics request (401) and an infinite loading spinner because metricsReady never became true while signInRequired was true.

Fixes #390

<img width="1920" height="1008" alt="image" src="https://github.com/user-attachments/assets/865388e0-0fe7-4247-b9b4-8d69054f82cb" />
