### PR TITLE
fix: surface day-by-day AI credit usage in My Usage tab

### DIFF
--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -54,7 +54,7 @@
 
           <v-row v-if="data.totals" dense class="px-3">
             <v-col cols="12" sm="6" md="3">
-              <v-card variant="tonal" color="indigo">
+              <v-card variant="tonal" color="indigo" class="h-100">
                 <v-card-text>
                   <div class="text-caption">Active days</div>
                   <div class="text-h4 font-weight-bold">{{ data.totals.total_active_days }}</div>
@@ -67,7 +67,7 @@
               </v-card>
             </v-col>
             <v-col cols="12" sm="6" md="3">
-              <v-card variant="tonal" color="green">
+              <v-card variant="tonal" color="green" class="h-100">
                 <v-card-text>
                   <div class="text-caption">Interactions</div>
                   <div class="text-h4 font-weight-bold">
@@ -77,7 +77,7 @@
               </v-card>
             </v-col>
             <v-col cols="12" sm="6" md="3">
-              <v-card variant="tonal" color="deep-purple">
+              <v-card variant="tonal" color="deep-purple" class="h-100">
                 <v-card-text>
                   <div class="text-caption">Accepted lines</div>
                   <div class="text-h4 font-weight-bold">
@@ -87,7 +87,7 @@
               </v-card>
             </v-col>
             <v-col cols="12" sm="6" md="3">
-              <v-card variant="tonal" color="cyan-darken-2">
+              <v-card variant="tonal" color="cyan-darken-2" class="h-100">
                 <v-card-text>
                   <div class="text-caption">AI credits used</div>
                   <div class="text-h4 font-weight-bold">
@@ -262,7 +262,7 @@
           <v-row v-else-if="data.dayRecords && data.dayRecords.length === 0" dense class="px-3 mt-2">
             <v-col cols="12">
               <v-alert type="info" variant="tonal" density="compact">
-                Pick a date range above to see the day-by-day AI credit usage breakdown.
+                No day-by-day AI credit activity recorded for you in the last 28 days.
               </v-alert>
             </v-col>
           </v-row>

--- a/server/api/my-usage.get.ts
+++ b/server/api/my-usage.get.ts
@@ -182,16 +182,20 @@ export default defineEventHandler(async (event): Promise<MyUsageResponse> => {
         dayRecords: myDays,
       };
     } else {
-      // No date range — use the pre-aggregated 28-day report
+      // No date range — use the pre-aggregated 28-day report. The report file
+      // already embeds per-day per-user rows in `day_totals`, so we can render
+      // the day-by-day chart without making 28 follow-up 1-day calls.
       const report = await fetchLatestUserReport(
         { scope, identifier, teamSlug: options.githubTeam },
         event.context.headers
       );
       const mine = report.user_totals.find(u => matchesLogin(myLogin, u.login)) ?? null;
+      const myDays = (report.day_totals ?? [])
+        .filter(r => matchesLogin(myLogin, r.user_login));
       baseResponse = {
         ...responseShell,
         totals: mine,
-        dayRecords: [],
+        dayRecords: myDays,
         reportStartDay: report.report_start_day,
         reportEndDay: report.report_end_day,
       };

--- a/server/services/github-copilot-usage-api.ts
+++ b/server/services/github-copilot-usage-api.ts
@@ -360,6 +360,12 @@ export interface UserReport {
   enterprise_id?: string;
   created_at?: string;
   user_totals: UserTotals[];
+  /**
+   * Per-user per-day rows. Present in the 28-day report file even though the
+   * outer endpoint is pre-aggregated — GitHub bundles the daily breakdown so
+   * consumers don't have to make N follow-up 1-day calls.
+   */
+  day_totals?: UserDayRecord[];
 }
 
 // --- Helper: merge breakdown arrays by key ---
@@ -983,9 +989,12 @@ export async function fetchLatestUserReport(
     download_links.map(url => downloadUserReport(url))
   );
 
-  // Merge: use first report as base, combine user_totals from all files
+  // Merge: use first report as base, combine user_totals AND day_totals from all files.
+  // The 28-day report file already contains per-day per-user rows (`day_totals`),
+  // so consumers can render a day-by-day chart without a separate 1-day fetch.
   const merged: UserReport = { ...reports[0]! };
   merged.user_totals = reports.flatMap(r => r.user_totals ?? []);
+  merged.day_totals = reports.flatMap(r => r.day_totals ?? []);
 
   return merged;
 }
@@ -1010,6 +1019,7 @@ export async function fetchUserReportForDate(
 
   const merged: UserReport = { ...reports[0]! };
   merged.user_totals = reports.flatMap(r => r.user_totals ?? []);
+  merged.day_totals = reports.flatMap(r => r.day_totals ?? []);
 
   return merged;
 }


### PR DESCRIPTION
## Problem

In the **My Usage** tab, users see only aggregate totals plus an info banner reading *"Pick a date range above to see the day-by-day AI credit usage breakdown."* — even though GitHub already returns the per-day per-user rows in the 28-day report response.

The handler was hard-coding `dayRecords: []` on the no-date-range path, throwing away free data and forcing a 28-call fan-out (via the date-range path) to recover it.

## Fix

1. **`UserReport` interface** — declare the optional `day_totals` field that GitHub's report files have always carried.
2. **`fetchLatestUserReport` / `fetchUserReportForDate`** — also `flatMap` `day_totals` (alongside `user_totals`) when merging multi-file reports.
3. **`/api/my-usage` no-range branch** — extract caller's rows from `report.day_totals` (filtered by `user_login` via `matchesLogin`) into `dayRecords` instead of hardcoding `[]`.
4. **`MyUsageViewer.vue`** — rewrite the empty-state copy (it now only appears when the user genuinely has zero activity) and add `h-100` to the four stat cards so the *Active days* / *Interactions* / *Accepted lines* / *AI credits used* cards align even when one of them carries the AI-adoption-phase chip.

## Verification

- 550/550 unit tests pass
- vue-tsc clean
- Empirical: `public/mock-data/new-api/organization-users-28-day-report.json` contains 107 `day_totals` rows with `day`, `user_login`, `ai_credits_used`, `totals_by_ide`, etc. — exactly the shape `MyUsageViewer`'s `aiCreditsDayPoints` reader expects.

## Out of scope

No version bump — leaving that for the merge commit or a coordinated release with PRs #401 / #402.
