### PR TITLE
fix(security): make NUXT_USAGE_ADMINS opt-in + configurable announcement banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@
 # Determines if mocked data should be used instead of making API calls.
 NUXT_PUBLIC_IS_DATA_MOCKED=true
 
+# Optional site-wide announcement banner text. Shown at the top of the dashboard
+# when non-empty; dismissible per browser tab session.
+# NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE=
+
 # Determines the scope of the API calls. 
 # Can be 'enterprise' or 'organization'. Legacy values 'team-organization'/'team-enterprise' are auto-normalized.
 NUXT_PUBLIC_SCOPE=organization

--- a/README.md
+++ b/README.md
@@ -433,25 +433,35 @@ NUXT_AUTHORIZED_EMAIL_DOMAINS=company.com
 Comma-separated allowlist of logins or email addresses that get **administrator privileges** on the dashboard. Administrators can:
 
 * See the **Billing tab** (aggregate AI-credit breakdown by SKU/model/cost-center/repo)
-* See **all users' rows** in the User Metrics tab and Seats Analysis (per [issue #398](https://github.com/github-copilot-resources/copilot-metrics-viewer/issues/398) — restrict user-level breakdown data to authorized users for Austrian/EU compliance)
+* See **all users' rows** in the User Metrics tab and Seats Analysis
+* Query any team on the Teams tab, including enterprise-scope team queries
+* Use the `?login=<other-user>` override on `/api/my-usage` and `/api/user-metrics-history`
+
+The gate is **opt-in**: when `NUXT_USAGE_ADMINS` is empty (default), the admin gate is **inactive** and every authenticated caller is treated as an admin — the dashboard behaves as it did before the allowlist was introduced. Populate the variable to enable row-level scoping (e.g. for GDPR / Austrian works-council compliance per [issue #398](https://github.com/github-copilot-resources/copilot-metrics-viewer/issues/398)); once set, anyone not on the list is restricted to their own row.
 
 ```
-# Closed by default — no one is admin; non-admins see only their own row on User Metrics
+# Opt-in mode: empty allowlist → gate inactive, all authenticated users see everything
 NUXT_USAGE_ADMINS=
 
-# Grant admin to specific logins/emails
+# Enable row-level scoping — only these logins/emails see cross-user data
 NUXT_USAGE_ADMINS=alice,bob@company.com
 ```
 
 > [!IMPORTANT]
-> **Breaking change in 3.11.0:** `NUXT_USAGE_ADMINS` was previously *open-by-default* (an empty value meant "everyone is admin"). It is now **closed-by-default**: anyone not explicitly listed is treated as a regular user and can only see their own row in User Metrics + Seats. Upgrade by setting `NUXT_USAGE_ADMINS` to your admin allowlist.
+> **Behaviour changes across recent releases:**
+> - **3.11.0** introduced `NUXT_USAGE_ADMINS` as a *closed-by-default* gate (empty = nobody is admin).
+> - The current release restores **opt-in** semantics: empty = everyone is admin. GitHub org owners no longer need to be listed to see other users' data unless you deliberately turn the gate on.
+> - There is **no automatic elevation from GitHub org/enterprise roles** — admin status is determined solely by this env var. If you want row-level scoping, list the small set of humans who should see cross-user data.
+> - **PAT-mode** (no OAuth provider configured — `NUXT_PUBLIC_REQUIRE_AUTH`, `NUXT_PUBLIC_USING_GITHUB_AUTH`, `NUXT_PUBLIC_IS_PUBLIC_APP`, `NUXT_PUBLIC_AUTH_PROVIDERS` all unset) always bypasses this gate, because there is no per-user identity to gate on. Lock PAT-mode deployments down at the network layer.
 
 > [!NOTE]
 > When `NUXT_GITHUB_BILLING_TOKEN` is unset, the Billing tab is shown to all users (admin or not) but renders a configuration-help placeholder instead of fetching data; the `NUXT_USAGE_ADMINS` gate only applies once the token is configured.
 
 The Billing tab exposes aggregate breakdowns (model / SKU / cost center) and an admin per-user breakdown. Per-user attribution depends on GitHub tagging each item with a `user`; some enterprise plans return only enterprise-level aggregates, in which case the per-user table is hidden behind an explanatory alert. The User Metrics `ai_credits_used` column and the My Usage spend card are independent of this.
 
-##### What non-admins see
+##### What non-admins see (only when `NUXT_USAGE_ADMINS` is populated)
+
+Row-level scoping only applies when the allowlist is set. With an empty allowlist every column below reads as "✅ all" for every caller.
 
 | Surface | Non-admin | Admin |
 |---|---|---|
@@ -459,10 +469,12 @@ The Billing tab exposes aggregate breakdowns (model / SKU / cost center) and an 
 | My Usage tab (own data) | ✅ own | ✅ own |
 | User Metrics tab | 🔒 own row only + banner | ✅ all rows |
 | Seats Analysis tab | 🔒 own seat only | ✅ all seats |
+| Teams tab — org scope | 🔒 only teams the caller is a member of | ✅ all teams |
+| Teams tab — enterprise scope with `?githubTeam=` | ❌ 403 (GitHub has no enterprise-wide team-membership API) | ✅ all teams |
 | Billing tab (token configured) | ❌ hidden | ✅ visible |
 | Billing tab (token unset) | ⚙️ configuration-help placeholder | ⚙️ configuration-help placeholder |
 
-The filter is enforced **server-side** — non-admin requests never receive other users' data over the wire.
+The filter is enforced **server-side** — non-admin requests never receive other users' data over the wire. On the Teams tab, KPI tiles automatically switch to aggregate signals (rather than derived-from-user-rows) when the caller is row-restricted, so team totals still render correctly.
 
 ##### Auth-mode matrix for Billing & My Usage tabs
 
@@ -516,6 +528,14 @@ Default is `false`. When set to `true`, the application uses a PostgreSQL databa
 
 ````
 NUXT_PUBLIC_ENABLE_HISTORICAL_MODE=false
+````
+
+#### NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE
+
+Optional site-wide announcement banner. When set to a non-empty string, an info banner with this text is shown at the top of the dashboard. Users can dismiss it for the current tab session; a new value re-shows the banner. Leave unset to hide the banner entirely.
+
+````
+NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE=Scheduled maintenance on Sat 08:00 UTC — the sync container will be paused for ~30 minutes.
 ````
 
 #### HTTP_PROXY

--- a/README.md
+++ b/README.md
@@ -116,9 +116,14 @@ Aggregate AI credit billing breakdown by model, SKU, cost center, and repository
 1. **When `NUXT_GITHUB_BILLING_TOKEN` is *not* configured** — the tab is shown to every dashboard user, but renders only a configuration-help placeholder (no data is fetched). This is a discoverability aid so operators learn the feature exists.
 2. **When `NUXT_GITHUB_BILLING_TOKEN` *is* configured** — the tab is **admin-only**: visible only to users on the `NUXT_USAGE_ADMINS` allowlist. In PAT-mode deployments (no OAuth provider configured) the allowlist is bypassed and the tab is visible to anyone who can reach the dashboard.
 
-**Why a separate token?** Billing endpoints have stricter auth than metrics endpoints — they require a **classic PAT** with `manage_billing:enterprise` (or `manage_billing:copilot`), SSO-authorized for the target enterprise. Fine-grained PATs and GitHub Apps cannot read billing today. Keeping `NUXT_GITHUB_BILLING_TOKEN` separate from `NUXT_GITHUB_TOKEN` means your metrics calls can keep using a GitHub App / fine-grained PAT while only billing uses the classic PAT.
+**Why a separate token?** Billing endpoints have stricter auth than metrics endpoints — they require a **classic PAT** with `manage_billing:enterprise` (for enterprise-owned orgs, SSO-authorized for the enterprise if enforced) or `manage_billing:copilot` (for standalone orgs). Fine-grained PATs and GitHub Apps cannot read billing today. Keeping `NUXT_GITHUB_BILLING_TOKEN` separate from `NUXT_GITHUB_TOKEN` means your metrics calls can keep using a GitHub App / fine-grained PAT while only billing uses the classic PAT.
 
-**Enterprise-owned orgs:** when a dashboard's org is consolidated under an enterprise (very common), `/organizations/{org}/settings/billing/ai_credit/usage` returns **404**. Set `NUXT_BILLING_ENTERPRISE=<enterprise-slug>` to route billing calls to `/enterprises/{slug}/...` regardless of the dashboard's scope. Without this override an org-scoped dashboard will see a 404 with a hint pointing at the variable.
+**Which billing endpoint gets called?**
+
+- **Standalone organizations (no parent enterprise):** billing calls go to `/organizations/{org}/settings/billing/ai_credit/usage` automatically — **leave `NUXT_BILLING_ENTERPRISE` unset**. A classic PAT with `manage_billing:copilot` scope is sufficient.
+- **Enterprise-owned organizations (org billing consolidated under an enterprise):** the org-level endpoint returns **404** because billing lives at the enterprise level. Set `NUXT_BILLING_ENTERPRISE=<enterprise-slug>` to route billing calls to `/enterprises/{slug}/...` — use a classic PAT with `manage_billing:enterprise` scope, SSO-authorized for that enterprise. Without this override an org-scoped dashboard will see a 404 with a hint pointing at the variable.
+
+Not sure which one applies to you? Call `GET /orgs/<your-org>` and look at the `enterprise` field — `null` means standalone, an object with a `slug` means enterprise-owned (use that slug).
 
 **Per-user attribution caveat:** the per-user breakdown depends on GitHub tagging each billing item with a `user`. Some enterprise plans (typically fully-pooled / centrally-billed) return only enterprise-level aggregates, in which case every user appears at $0 in the per-user table; the Billing tab surfaces an explanatory alert in that state. The My Usage tab and the User Metrics `ai_credits_used` column are independent of this and still work.
 
@@ -128,7 +133,7 @@ Each username in the Per-user breakdown table is a clickable chip. Selecting a c
 
 No user selected → the section shows an info banner explaining the feature. Clicking a chip a second time (or "Clear selection") returns to the banner state.
 
-**Requires** the same `NUXT_GITHUB_BILLING_TOKEN` + `NUXT_BILLING_ENTERPRISE` variables as the rest of the Billing tab. The drill-down endpoint (`/api/my-usage?login=<other>`) is gated by `NUXT_USAGE_ADMINS`; non-admins receive 403. In PAT-only deployments the operator is admin-by-PAT and the drill-down works without an OAuth session.
+**Requires** `NUXT_GITHUB_BILLING_TOKEN` (always) and — only for enterprise-owned orgs — `NUXT_BILLING_ENTERPRISE`. Standalone orgs work without the enterprise slug. The drill-down endpoint (`/api/my-usage?login=<other>`) is gated by `NUXT_USAGE_ADMINS`; non-admins receive 403. In PAT-only deployments the operator is admin-by-PAT and the drill-down works without an OAuth session.
 
 ![Billing tab — Per-user breakdown with chip-style logins and the info banner state](images/billing-user-insights-banner.png)
 
@@ -149,7 +154,7 @@ GitHub builds the export server-side and returns one or more signed download URL
 
 The recent-jobs table shows status, row count, who triggered, and a hover tooltip on the row count surfacing **what was fetched vs. skipped** (so you can verify gap-mode actually pruned re-fetches of already-ingested ranges).
 
-**Requires:** `NUXT_GITHUB_BILLING_TOKEN` set to a classic PAT with `manage_billing:enterprise` (same token used by the live Billing tab) plus `NUXT_BILLING_ENTERPRISE` for the enterprise slug. Postgres must be configured (see the storage section).
+**Requires:** an **enterprise-owned org** — the CSV export endpoint (`/enterprises/{slug}/settings/billing/usage_report`) is enterprise-only. Standalone orgs must use the live Billing tab instead. Set `NUXT_GITHUB_BILLING_TOKEN` to a classic PAT with `manage_billing:enterprise` (SSO-authorized if enforced) and `NUXT_BILLING_ENTERPRISE` to the enterprise slug. Postgres must be configured (see the storage section).
 
 ![Admin panel — Billing CSV ingest controls](images/billing-csv-ingest.png)
 
@@ -360,13 +365,23 @@ NUXT_GITHUB_BILLING_TOKEN=ghp_classic_pat_with_manage_billing_enterprise
 
 #### NUXT_BILLING_ENTERPRISE
 
-Optional. **Forces billing calls to query `/enterprises/{slug}/...` regardless of dashboard scope.** Set to the enterprise slug when an org-scoped dashboard's org is consolidated under an enterprise (the typical case — GitHub returns 404 on the `/organizations/{org}/...` billing endpoint for those orgs).
+Optional. **Set only when your organization's billing is consolidated under a GitHub enterprise.** When set, it forces billing calls to `/enterprises/{slug}/settings/billing/ai_credit/usage` regardless of the dashboard's scope.
+
+**Leave unset for standalone organizations** — the app will automatically use `/organizations/{org}/settings/billing/ai_credit/usage`, which is the correct endpoint for orgs that aren't part of an enterprise.
+
+To check whether your org is enterprise-owned:
+
+```bash
+curl -H "Authorization: token <PAT>" https://api.github.com/orgs/<your-org> | jq '.enterprise'
+```
+
+`null` → standalone (leave `NUXT_BILLING_ENTERPRISE` unset); an object with a `slug` → enterprise-owned (use that slug).
 
 ````
 NUXT_BILLING_ENTERPRISE=my-enterprise-slug
 ````
 
-If you get a 404 from the Billing tab with the dashboard scoped to an organization, the error message will point you at this variable.
+If you get a 404 from the Billing tab with the dashboard scoped to an enterprise-owned organization, the error message will point you at this variable.
 
 #### NUXT_GITHUB_API_BASE_URL
 
@@ -484,10 +499,10 @@ Metrics endpoints (User Metrics, My Usage, Seats) accept any token type. Billing
 |---|---|---|---|---|
 | My Usage tab metrics | ✅ fixtures | ✅ | ✅ | ✅ |
 | User Metrics `ai_credits_used` column | ✅ fixtures | ✅ | ✅ | ✅ |
-| My Usage "Your AI credit spend" card | ✅ fixtures | — | — | ✅ with `manage_billing:enterprise` |
-| Billing tab (aggregate + per-user) | ✅ fixtures | — | — | ✅ with `manage_billing:enterprise` |
+| My Usage "Your AI credit spend" card | ✅ fixtures | — | — | ✅ with `manage_billing:enterprise` (enterprise-owned orgs) or `manage_billing:copilot` (standalone orgs) |
+| Billing tab (aggregate + per-user) | ✅ fixtures | — | — | ✅ with `manage_billing:enterprise` (enterprise-owned orgs) or `manage_billing:copilot` (standalone orgs) |
 
-Even when on the admin allowlist, an admin only sees billing data if `NUXT_GITHUB_BILLING_TOKEN` is set AND that classic PAT is SSO-authorized for the target enterprise. If GitHub returns 403, the tab surfaces the message inline so it's clear which side needs adjustment.
+Even when on the admin allowlist, an admin only sees billing data if `NUXT_GITHUB_BILLING_TOKEN` is set AND the classic PAT has the right scope for the org's billing setup — `manage_billing:enterprise` (SSO-authorized for the target enterprise) for enterprise-owned orgs, or `manage_billing:copilot` for standalone orgs. If GitHub returns 403 or 404, the tab surfaces the message inline so it's clear which side needs adjustment (see `NUXT_BILLING_ENTERPRISE` above for the standalone-vs-enterprise-owned decision).
 
 #### OAuth provider variables
 

--- a/app/components/MainComponent.vue
+++ b/app/components/MainComponent.vue
@@ -93,22 +93,19 @@
 
     </v-toolbar>
 
-      <!-- v3.0 Migration Banner -->
+      <!-- Site-wide announcement banner (NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE) -->
     <v-banner
-      v-if="showMigrationBanner"
+      v-if="showAnnouncementBanner"
       color="info"
       icon="mdi-information"
       lines="two"
-      class="migration-banner"
+      class="announcement-banner"
     >
       <v-banner-text>
-        <strong>v3.0 — New Copilot Usage Metrics API.</strong>
-        Your GitHub App now requires the <strong>"Organization Copilot metrics: Read"</strong> permission.
-        Update at GitHub → Settings → Developer settings → GitHub Apps → Permissions.
-        <a href="https://docs.github.com/en/enterprise-cloud@latest/rest/copilot/copilot-usage-metrics" target="_blank">Learn more</a>
+        <span style="white-space: pre-line">{{ announcementMessage }}</span>
       </v-banner-text>
       <template #actions>
-        <v-btn text="Dismiss" @click="showMigrationBanner = false" />
+        <v-btn text="Dismiss" @click="dismissAnnouncement" />
       </template>
     </v-banner>
 
@@ -347,7 +344,23 @@ export default defineNuxtComponent({
     AiChatPanel,
     AdminPanel
   },
+  computed: {
+    announcementMessage(): string {
+      return (this.config?.public?.announcementMessage as string) || '';
+    },
+    showAnnouncementBanner(): boolean {
+      return !!this.announcementMessage && !this.announcementDismissed;
+    },
+  },
   methods: {
+    dismissAnnouncement() {
+      this.announcementDismissed = true;
+      if (import.meta.client) {
+        try {
+          sessionStorage.setItem('announcementDismissed', this.announcementMessage);
+        } catch { /* sessionStorage unavailable */ }
+      }
+    },
     logout() {
       const { clear } = useUserSession()
       this.metrics = [];
@@ -522,7 +535,7 @@ export default defineNuxtComponent({
       userMetrics: [] as UserTotals[],
       userMetricsHistory: [] as UserMetricsHistoryEntry[],
       apiError: undefined as string | undefined,
-      showMigrationBanner: false,
+      announcementDismissed: false,
       showDateRange: false,
       showAdminPanel: false,
       billingEnabled: true,
@@ -536,6 +549,17 @@ export default defineNuxtComponent({
     this.tabItems.unshift(this.getDisplayTabName(this.itemName));
     
     this.config = useRuntimeConfig();
+
+    // Restore prior dismissal of the announcement banner (per-tab session),
+    // keyed on the exact message so a new announcement re-appears.
+    if (import.meta.client && this.announcementMessage) {
+      try {
+        const dismissed = sessionStorage.getItem('announcementDismissed');
+        if (dismissed === this.announcementMessage) {
+          this.announcementDismissed = true;
+        }
+      } catch { /* sessionStorage unavailable */ }
+    }
 
     // Add teams tab for organization/enterprise to allow team comparison
     if (this.itemName === 'organization' || this.itemName === 'enterprise') {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -148,6 +148,10 @@ export default defineNuxtConfig({
       enableAiChat: true,  // Enable AI-powered chat for metrics Q&A (NUXT_PUBLIC_ENABLE_AI_CHAT)
       entraClientId: '',    // NUXT_PUBLIC_ENTRA_CLIENT_ID — app registration client ID for MSAL popup auth
       entraTenantId: '',    // NUXT_PUBLIC_ENTRA_TENANT_ID — tenant ID (defaults to 'common' for multi-tenant)
+      // Optional site-wide announcement banner. When set, an info banner with this
+      // text is shown at the top of the dashboard. Users can dismiss it for the
+      // current tab session. (NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE)
+      announcementMessage: '',
     }
   }
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-metrics-viewer",
-      "version": "3.11.0",
+      "version": "3.11.1",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-browser": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.0",
+  "version": "3.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/utils/restrict-user-rows.ts
+++ b/server/utils/restrict-user-rows.ts
@@ -1,14 +1,22 @@
 /**
- * User-data visibility filter for issue #398 (Austrian/EU compliance).
+ * User-data visibility filter (originally issue #398 — Austrian/EU compliance).
  *
- * Non-admin callers must NOT see other users' breakdown rows. Each endpoint
- * that returns per-user records (currently /api/user-metrics, /api/seats)
+ * When the deployment operator populates `NUXT_USAGE_ADMINS`, non-admin
+ * callers must NOT see other users' breakdown rows. Each endpoint that
+ * returns per-user records (currently /api/user-metrics, /api/seats)
  * delegates to this helper to strip out everyone except the session login
  * itself.
+ *
+ * The gate is OPT-IN: when the allowlist is empty, `isUsageAdminForEvent`
+ * returns `true` for every caller and this filter becomes a no-op. To
+ * enforce row-level scoping (GDPR / works-council style), populate
+ * NUXT_USAGE_ADMINS with the small set of logins that should see cross-
+ * user data.
  *
  * Behaviour matrix:
  *   - Mock mode                                     → return rows unchanged
  *   - PAT-mode (no OAuth configured)                → return rows unchanged
+ *   - Allowlist empty (opt-in gate inactive)        → return rows unchanged
  *   - isUsageAdminForEvent === true                 → return rows unchanged
  *   - No session login resolvable                   → return []
  *   - Otherwise                                     → keep only the row whose

--- a/server/utils/team-membership.ts
+++ b/server/utils/team-membership.ts
@@ -1,5 +1,5 @@
 /**
- * Team-membership gating for non-admin callers (issue #398, Policy C).
+ * Team-membership gating for non-admin callers (originally issue #398, Policy C).
  *
  * Background: aggregate team metrics (interactions, accepted lines, etc.)
  * are derived from individual contributors. On small teams (2-3 people) a
@@ -8,8 +8,13 @@
  * productivity data must not be exposed to people who are not their direct
  * collaborators.
  *
- * Policy:
- *   - Usage admins (NUXT_USAGE_ADMINS) — unchanged, see all teams.
+ * The gate is OPT-IN and only activates when NUXT_USAGE_ADMINS is populated.
+ * With an empty allowlist every caller is treated as an admin and this gate
+ * is a no-op — a deployment operator must opt INTO row-level scoping by
+ * declaring the admin set.
+ *
+ * Policy (only relevant when NUXT_USAGE_ADMINS is set):
+ *   - Usage admins (NUXT_USAGE_ADMINS) — see all teams.
  *   - PAT-mode deployments (no OAuth provider) — bypassed, no session
  *     identity to gate on. Operators are expected to lock these down at the
  *     network layer.

--- a/server/utils/usage-admin.ts
+++ b/server/utils/usage-admin.ts
@@ -6,23 +6,30 @@
  *      breakdown by SKU/model/cost-center/repo.
  *   2. **User-level breakdown data** (/api/user-metrics, /api/seats) —
  *      per-user names and metrics. Non-admins are restricted to their own
- *      row only (issue #398 — Austrian/EU compliance).
+ *      row only (issue #398 — Austrian/EU compliance) — but only when an
+ *      allowlist is actually configured.
  *
- * Gating is **CLOSED-BY-DEFAULT** in OAuth-mode deployments: when
- * NUXT_USAGE_ADMINS is empty, NO ONE is an admin. This is a deliberate
- * breaking change from earlier versions to align with the principle of
- * least privilege and the EU compliance requirement in issue #398.
+ * Gating is **OPT-IN**: when NUXT_USAGE_ADMINS is empty, the allowlist is
+ * treated as inactive and every authenticated caller is treated as an admin.
+ * A deployment operator opts INTO row-level restrictions by populating
+ * NUXT_USAGE_ADMINS with the explicit set of logins/emails that should see
+ * cross-user data. Everyone else is then restricted to their own row.
+ *
+ * Rationale for opt-in (rather than closed-by-default):
+ *   - The dashboard's primary value is org-wide visibility. A closed-by-
+ *     default gate silently hid data from GitHub org owners on upgrade,
+ *     which was a surprising behaviour change from earlier versions.
+ *   - Deployments that need GDPR/works-council-style row-level scoping
+ *     opt in explicitly by listing the small admin set — the audit trail
+ *     is the presence of the env var itself.
  *
  * In **PAT-mode deployments** (no OAuth provider configured, recognised via
  * requireAuth / usingGithubAuth / isPublicApp / authProviders all falsy)
  * there is no per-user identity, so the allowlist has no signal to act on.
- * In that case we treat every caller as admin so the Billing tab and
- * per-user breakdowns remain usable. PAT-mode is the legacy single-tenant
- * model — it should be locked down at the network layer (firewall / IP
- * allowlist) rather than at the row layer.
- *
- * To restore the old "everyone sees everything" behaviour, deployments must
- * set `NUXT_USAGE_ADMINS` to an explicit allowlist of logins/emails.
+ * Every caller is treated as admin so the Billing tab and per-user
+ * breakdowns remain usable. PAT-mode is the legacy single-tenant model —
+ * it should be locked down at the network layer (firewall / IP allowlist)
+ * rather than at the row layer.
  *
  * We do NOT support email-domain wildcards — only explicit logins / email
  * addresses — so the admin set is auditable.
@@ -35,7 +42,8 @@ import type { AuthorizedIdentity } from './authorization'
  * Pure check — accepts an explicit allowlist string so it can be unit-tested
  * without mocking Nuxt runtime config.
  *
- * Closed-by-default: empty / whitespace / delimiters-only allowlist → false.
+ * Opt-in gating: empty / whitespace / delimiters-only allowlist means the
+ * gate is inactive and every caller is treated as admin.
  *
  * @param identity   The authenticated user's login and/or email
  * @param allowlist  Comma-separated logins/emails
@@ -44,9 +52,11 @@ export function isUsageAdmin(
   identity: AuthorizedIdentity,
   allowlist: string
 ): boolean {
-  // Closed-by-default: an unconfigured allowlist means NO admin access.
+  // Opt-in gating: an unconfigured allowlist means the admin gate is inactive
+  // and every caller is treated as an admin (open by default). Operators opt
+  // INTO row-level restrictions by populating NUXT_USAGE_ADMINS.
   if (!allowlist || !allowlist.trim()) {
-    return false
+    return true
   }
 
   const allowed = allowlist
@@ -54,9 +64,9 @@ export function isUsageAdmin(
     .map(s => s.trim().toLowerCase())
     .filter(Boolean)
 
-  // A string like ",,," parses to zero entries — still treat as closed.
+  // A string like ",,," parses to zero entries — treat as unconfigured (open).
   if (allowed.length === 0) {
-    return false
+    return true
   }
 
   const login = identity.login?.toLowerCase()
@@ -75,7 +85,7 @@ export function isUsageAdmin(
  * H3 wrapper that reads the allowlist from runtime config (NUXT_USAGE_ADMINS).
  *
  * Behaviour:
- *   - allowlist empty                              → false (closed by default)
+ *   - allowlist empty                              → true  (opt-in: gate inactive)
  *   - allowlist set, session present + on list     → true
  *   - allowlist set, session present + not on list → false
  *   - allowlist set, NO session                    → false
@@ -96,14 +106,15 @@ export async function isUsageAdminForEvent(
     pub.requireAuth || pub.usingGithubAuth || pub.isPublicApp || !!pub.authProviders
   if (!authConfigured) return true
 
-  // Closed-by-default — empty or whitespace-only allowlist denies access.
+  // Opt-in gating — empty or whitespace-only allowlist means every authenticated
+  // caller is treated as an admin.
   if (!allowlist.trim()) {
-    return false
+    return true
   }
-  // A "list" with only delimiters is also treated as closed.
+  // A "list" with only delimiters is also treated as unconfigured (open).
   const parsed = allowlist.split(',').map(s => s.trim()).filter(Boolean)
   if (parsed.length === 0) {
-    return false
+    return true
   }
 
   const session = await getUserSession(event).catch(() => null)

--- a/tests/billing-credits.standalone-org.spec.ts
+++ b/tests/billing-credits.standalone-org.spec.ts
@@ -1,0 +1,210 @@
+// @vitest-environment node
+/**
+ * End-to-end simulation of the standalone-org billing flow reported in
+ * issue #398 (@mfischbacher5600 / org "Eurofunk").
+ *
+ * The reporter has a **standalone organization** — `GET /orgs/<org>` returns
+ * `enterprise: null, parent: null`. The org-level billing endpoint returns
+ * HTTP 200 for that setup (verified in the issue's diagnostic dump), so the
+ * dashboard MUST NOT require `NUXT_BILLING_ENTERPRISE` in this case.
+ *
+ * This spec pins the handler's wiring for that scenario:
+ *   - empty `NUXT_USAGE_ADMINS` allowlist → treated as admin (opt-in flip)
+ *   - unset `NUXT_BILLING_ENTERPRISE` → URL is `/organizations/{org}/...`
+ *   - live GitHub 200 → response passthrough, no DB branch
+ *   - live GitHub 404 → sharpened error mentioning `NUXT_BILLING_ENTERPRISE`
+ *
+ * All four are the things that could regress and silently break issue #398
+ * again for standalone orgs. Keep as a regression guard.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.hoisted(() => {
+  (globalThis as any).defineEventHandler = (h: any) => h;
+  (globalThis as any).createError = ({ statusCode, statusMessage, data }: { statusCode: number; statusMessage: string; data?: unknown }) => {
+    const err: any = new Error(statusMessage);
+    err.statusCode = statusCode;
+    err.statusMessage = statusMessage;
+    err.data = data;
+    return err;
+  };
+  (globalThis as any).getQuery = () => (globalThis as any).__test_query || {};
+  (globalThis as any).useRuntimeConfig = () => (globalThis as any).__test_config || {};
+  (globalThis as any).setResponseHeader = () => {};
+  (globalThis as any).$fetch = vi.fn();
+});
+
+function setQuery(q: Record<string, string>) { (globalThis as any).__test_query = q; }
+function setConfig(c: Record<string, unknown>) { (globalThis as any).__test_config = c; }
+
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => (globalThis as any).__test_config || {},
+  defineNuxtPlugin: (h: any) => h,
+}));
+
+// Simulate the post-#407 opt-in flip: empty NUXT_USAGE_ADMINS ⇒ everyone-admin.
+// `requireUsageAdmin` returns undefined (no throw), matching that behaviour.
+vi.mock('../server/utils/usage-admin', () => ({
+  requireUsageAdmin: vi.fn(async () => undefined),
+  isUsageAdminForEvent: vi.fn(async () => true),
+  getSessionLoginForFilter: vi.fn(async () => null),
+}));
+
+// No DB configured (Postgres unset) → decideSource is never called for
+// org-scoped calls without NUXT_BILLING_ENTERPRISE. Still mock defensively so
+// a regression that starts calling it will fail here instead of hitting a real
+// Postgres client.
+const mockDecide = vi.fn();
+vi.mock('../server/services/billing-credit-reader', () => ({
+  decideSource: (...a: any[]) => mockDecide(...a),
+  aggregateForBilling: vi.fn(),
+  aggregateForBillingByUser: vi.fn(),
+  resolveWindow: (input: { year?: number; month?: number }) => {
+    const y = input.year ?? 2026;
+    const m = input.month ?? 7;
+    return {
+      startDate: `${y}-${String(m).padStart(2, '0')}-01`,
+      endDate: `${y}-${String(m).padStart(2, '0')}-31`,
+      timePeriod: { year: y, month: m },
+    };
+  },
+}));
+
+import billingHandler from '../server/api/billing-credits.get';
+
+// Shape mirrors the real /organizations/{org}/settings/billing/ai_credit/usage
+// response @mfischbacher5600 posted on issue #398 (2026-07-01).
+const standaloneOrgResponse = {
+  timePeriod: { year: 2026, month: 7 },
+  organization: 'Eurofunk',
+  usageItems: [
+    {
+      product: 'Copilot',
+      sku: 'Copilot AI Credits',
+      model: 'Auto: Claude Haiku 4.5',
+      unitType: 'ai-credits',
+      pricePerUnit: 0.01,
+      grossQuantity: 567.043776,
+      grossAmount: 5.67043776,
+      discountQuantity: 567.043776,
+      discountAmount: 5.67043776,
+      netQuantity: 0.0,
+      netAmount: 0.0,
+    },
+    {
+      product: 'Copilot',
+      sku: 'Copilot AI Credits',
+      model: 'Auto: GPT-5.4',
+      unitType: 'ai-credits',
+      pricePerUnit: 0.01,
+      grossQuantity: 1131.45417,
+      grossAmount: 11.3145417,
+      discountQuantity: 1131.45417,
+      discountAmount: 11.3145417,
+      netQuantity: 0.0,
+      netAmount: 0.0,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Reporter's exact config: scope=organization, no billingEnterprise, classic PAT set.
+  setConfig({
+    billingEnterprise: '',
+    githubBillingToken: 'ghp_classic_pat_with_manage_billing_copilot',
+    githubApiBaseUrl: '',
+  });
+});
+
+describe('GET /api/billing-credits — standalone org (issue #398 scenario)', () => {
+  it('routes to /organizations/{org}/settings/billing/ai_credit/usage when NUXT_BILLING_ENTERPRISE is unset', async () => {
+    setQuery({ scope: 'organization', githubOrg: 'Eurofunk', year: '2026', month: '7' });
+    ((globalThis as any).$fetch as any).mockResolvedValueOnce(standaloneOrgResponse);
+
+    const result = await billingHandler({} as any);
+
+    // The DB branch must not fire — no enterprise slug is resolvable.
+    expect(mockDecide).not.toHaveBeenCalled();
+
+    // Exactly one live call, hitting the ORG endpoint (not /enterprises/...).
+    const calls = ((globalThis as any).$fetch as any).mock.calls;
+    expect(calls).toHaveLength(1);
+    const calledUrl: string = calls[0][0];
+    expect(calledUrl).toContain('/organizations/Eurofunk/settings/billing/ai_credit/usage');
+    expect(calledUrl).not.toContain('/enterprises/');
+
+    // Response passes through unchanged.
+    expect(result.organization).toBe('Eurofunk');
+    expect(result.usageItems).toHaveLength(2);
+    expect(result.usageItems[0]!.grossAmount).toBeCloseTo(5.67043776, 6);
+  });
+
+  it('sends the classic PAT via `token` scheme and the required X-GitHub-Api-Version header', async () => {
+    setQuery({ scope: 'organization', githubOrg: 'Eurofunk', year: '2026', month: '7' });
+    ((globalThis as any).$fetch as any).mockResolvedValueOnce(standaloneOrgResponse);
+
+    await billingHandler({} as any);
+
+    const calls = ((globalThis as any).$fetch as any).mock.calls;
+    const opts = calls[0][1] as { headers: Headers };
+    const headers = opts.headers;
+    expect(headers.get('authorization')).toBe('token ghp_classic_pat_with_manage_billing_copilot');
+    expect(headers.get('x-github-api-version')).toBe('2026-03-10');
+    expect(headers.get('accept')).toBe('application/vnd.github+json');
+  });
+
+  it('forwards year/month query params to GitHub', async () => {
+    setQuery({ scope: 'organization', githubOrg: 'Eurofunk', year: '2026', month: '7' });
+    ((globalThis as any).$fetch as any).mockResolvedValueOnce(standaloneOrgResponse);
+
+    await billingHandler({} as any);
+
+    const calledUrl: string = ((globalThis as any).$fetch as any).mock.calls[0][0];
+    expect(calledUrl).toContain('year=2026');
+    expect(calledUrl).toContain('month=7');
+  });
+
+  it('surfaces a sharpened 404 message pointing at NUXT_BILLING_ENTERPRISE when the org endpoint 404s', async () => {
+    // Some orgs (e.g. enterprise-owned ones that the operator forgot to set
+    // NUXT_BILLING_ENTERPRISE for) will 404 on /organizations/... — the error
+    // must tell them exactly which env var to set.
+    setQuery({ scope: 'organization', githubOrg: 'some-ent-owned-org', year: '2026', month: '7' });
+    ((globalThis as any).$fetch as any).mockRejectedValueOnce({
+      statusCode: 404,
+      data: { message: 'Not Found' },
+    });
+
+    let caught: any;
+    try {
+      await billingHandler({} as any);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeTruthy();
+    expect(caught.statusCode).toBe(404);
+    expect(caught.statusMessage).toMatch(/NUXT_BILLING_ENTERPRISE/);
+    expect(caught.statusMessage).toMatch(/some-ent-owned-org/);
+  });
+
+  it('passes through non-404 errors verbatim (no misleading NUXT_BILLING_ENTERPRISE hint)', async () => {
+    setQuery({ scope: 'organization', githubOrg: 'Eurofunk', year: '2026', month: '7' });
+    ((globalThis as any).$fetch as any).mockRejectedValueOnce({
+      statusCode: 403,
+      data: { message: 'Resource not accessible by personal access token' },
+    });
+
+    let caught: any;
+    try {
+      await billingHandler({} as any);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught.statusCode).toBe(403);
+    expect(caught.statusMessage).not.toMatch(/NUXT_BILLING_ENTERPRISE/);
+    expect(caught.statusMessage).toMatch(/Resource not accessible/);
+  });
+});

--- a/tests/usage-admin.spec.ts
+++ b/tests/usage-admin.spec.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for the usage-admin pure check.
  *
- * Verifies the strict, closed-by-default behaviour:
- *   - Empty allowlist → false for everyone (even authenticated users).
- *   - Comma/whitespace handling.
+ * Verifies the opt-in behaviour:
+ *   - Empty allowlist → true for everyone (gate inactive, opt-in mode).
+ *   - When set, comma/whitespace/case handling on entries.
  *   - Case-insensitive matching for both login and email.
  *   - No domain-wildcard matching (only explicit entries).
  */
@@ -12,24 +12,24 @@ import { describe, it, expect } from 'vitest';
 import { isUsageAdmin } from '../server/utils/usage-admin';
 
 describe('isUsageAdmin', () => {
-  describe('closed-by-default when allowlist is empty', () => {
-    it('returns false when allowlist is empty', () => {
-      expect(isUsageAdmin({ login: 'alice' }, '')).toBe(false);
+  describe('opt-in gate: empty allowlist means everyone is admin', () => {
+    it('returns true when allowlist is empty', () => {
+      expect(isUsageAdmin({ login: 'alice' }, '')).toBe(true);
     });
 
-    it('returns false when allowlist is whitespace only', () => {
-      expect(isUsageAdmin({ login: 'alice' }, '   ')).toBe(false);
+    it('returns true when allowlist is whitespace only', () => {
+      expect(isUsageAdmin({ login: 'alice' }, '   ')).toBe(true);
     });
 
-    it('returns false when allowlist is comma-only', () => {
-      expect(isUsageAdmin({ login: 'alice' }, ',,,')).toBe(false);
+    it('returns true when allowlist is comma-only', () => {
+      expect(isUsageAdmin({ login: 'alice' }, ',,,')).toBe(true);
     });
 
-    it('returns false when identity has no login or email (closed mode)', () => {
-      expect(isUsageAdmin({}, '')).toBe(false);
+    it('returns true even when identity is empty (unconfigured gate is open)', () => {
+      expect(isUsageAdmin({}, '')).toBe(true);
     });
 
-    it('returns false when allowlist is set but identity has no login or email', () => {
+    it('returns false when allowlist IS set but identity has no login or email', () => {
       expect(isUsageAdmin({}, 'alice,bob')).toBe(false);
     });
   });


### PR DESCRIPTION
## Summary

Two related fixes bundled together — both driven by the observation that PR #401's closed-by-default admin gate silently locked GitHub org owners and `NUXT_PUBLIC_IS_PUBLIC_APP` deployments out of cross-user data on upgrade.

### 1. `NUXT_USAGE_ADMINS` is now OPT-IN (open-when-empty)

**Empty allowlist → gate is inactive → every authenticated caller is treated as admin.** Restores pre-3.11 behavior. Operators who want row-level scoping (GDPR / Austrian works-council style, per #398) opt IN by populating the allowlist.

**Why:** the closed-by-default model shipped in #401 had two surprising side effects:
- GitHub org/enterprise owners no longer see anyone else's data unless explicitly listed (no auto-elevation from GitHub roles anywhere in the gate).
- `NUXT_PUBLIC_IS_PUBLIC_APP` deployments — which used to be "everyone authenticated sees everything" — silently regressed to per-user isolation.

Under the new model both are fixed as a side effect of the flip; no dedicated `isPublicApp` code path needed.

### 2. New `NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE`

Replaces the hardcoded v3.0 migration banner in ``MainComponent.vue``. When set, renders a dismissible info banner at the top of the dashboard. `sessionStorage` keys the dismissal on the message text so changing the env var re-shows the banner.

Example:
\`\`\`
NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE=Scheduled maintenance Sat 08:00 UTC — sync paused ~30 min.
\`\`\`

## Behavior matrix after this PR

| Deployment | \`NUXT_USAGE_ADMINS\` | User Metrics/Seats | Billing tab | Teams tab |
|---|---|---|---|---|
| PAT-mode (no OAuth) | any | all | visible | unrestricted |
| OAuth / isPublicApp | **empty** | all | visible | unrestricted |
| OAuth / isPublicApp | **set**, caller listed | all | visible | all teams |
| OAuth / isPublicApp | **set**, caller not listed | own row + banner | hidden | org: member-only; enterprise+\`?githubTeam=\`: 403 |

## Files

- \`server/utils/usage-admin.ts\` — flip empty-list branch (both pure and event wrapper) from \`false\` to \`true\`.
- \`server/utils/restrict-user-rows.ts\`, \`server/utils/team-membership.ts\` — doc-blocks only; behavior unchanged (both short-circuit on \`isAdmin=true\`).
- \`tests/usage-admin.spec.ts\` — expectations flipped for empty-list cases. Populated-list cases unchanged.
- \`nuxt.config.ts\` — new \`public.announcementMessage\` runtimeConfig.
- \`app/components/MainComponent.vue\` — banner + dismiss logic; removed hardcoded v3.0 banner.
- \`README.md\` — rewrote the \`NUXT_USAGE_ADMINS\` section, expanded the "what non-admins see" table with Teams rows, documented the announcement banner.
- \`.env.example\` — documented \`NUXT_PUBLIC_ANNOUNCEMENT_MESSAGE\`.

## Compatibility note

Deployments that upgraded to 3.11.x specifically because they wanted the closed-by-default scoping (e.g. Austrian works-council compliance customers) MUST populate \`NUXT_USAGE_ADMINS\` after this change to retain that behavior. The README's "Behaviour changes across recent releases" callout documents this.

## Verification

- 715/715 unit tests pass (\`npm test\`)
- Production build succeeds (\`npm run build\`)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>