### PR TITLE
fix(#410): compute rolling active-user windows for team metrics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,9 @@
 name: copilot-metrics-viewer
 description: Nuxt 3 web application for GitHub Copilot usage metrics and analytics
 stack: Vue.js, TypeScript, Nuxt 3, Vuetify, Chart.js
-version: 3.11.3
+instructions_version: 5.0
+# Note: this `instructions_version` tracks the instructions document itself.
+# The app version lives in `package.json` — do not sync this field with it.
 ---
 
 # GitHub Copilot Metrics Viewer
@@ -155,26 +157,29 @@ The CI release workflow **hard-fails** if the git tag does not match `package.js
 
 **During code review, flag a missing version bump if the PR:**
 - Is labelled as a release or contains a changelog/release-notes update
-- Bumps the git tag (e.g. `v3.12.0`) without a matching change to `"version"` in `package.json`
+- Bumps the git tag (e.g. `v1.0.0`) without a matching change to `"version"` in `package.json`
+
+> The version numbers below are illustrative examples only. The real current
+> version lives in `package.json` — always read it from there.
 
 **The correct release workflow:**
 1. In a commit on `main`, bump `package.json` **and** `package-lock.json` together — always use
    `npm version` (never edit `package.json` manually) so both files stay in sync:
    ```bash
-   # Patch bump (3.11.2 → 3.11.3):
+   # Patch bump (e.g. 1.0.0 → 1.0.1):
    npm version patch --no-git-tag-version
 
    # Or set an explicit version:
-   npm version 3.12.0 --no-git-tag-version
+   npm version 1.0.0 --no-git-tag-version
 
    git add package.json package-lock.json
-   git commit -m "chore: bump version to 3.12.0"
+   git commit -m "chore: bump version to 1.0.0"
    git push origin main
    ```
 2. Push the matching release tag:
    ```bash
-   git tag v3.12.0
-   git push origin v3.12.0
+   git tag v1.0.0
+   git push origin v1.0.0
    ```
 3. The CI pipeline checks `tag == package.json version` and fails with a clear error if they differ.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 name: copilot-metrics-viewer
 description: Nuxt 3 web application for GitHub Copilot usage metrics and analytics
 stack: Vue.js, TypeScript, Nuxt 3, Vuetify, Chart.js
-version: 3.6.1
+version: 3.11.3
 ---
 
 # GitHub Copilot Metrics Viewer
@@ -155,26 +155,26 @@ The CI release workflow **hard-fails** if the git tag does not match `package.js
 
 **During code review, flag a missing version bump if the PR:**
 - Is labelled as a release or contains a changelog/release-notes update
-- Bumps the git tag (e.g. `v3.7.0`) without a matching change to `"version"` in `package.json`
+- Bumps the git tag (e.g. `v3.12.0`) without a matching change to `"version"` in `package.json`
 
 **The correct release workflow:**
 1. In a commit on `main`, bump `package.json` **and** `package-lock.json` together — always use
    `npm version` (never edit `package.json` manually) so both files stay in sync:
    ```bash
-   # Patch bump (3.6.1 → 3.6.2):
+   # Patch bump (3.11.2 → 3.11.3):
    npm version patch --no-git-tag-version
 
    # Or set an explicit version:
-   npm version 3.7.0 --no-git-tag-version
+   npm version 3.12.0 --no-git-tag-version
 
    git add package.json package-lock.json
-   git commit -m "chore: bump version to 3.7.0"
+   git commit -m "chore: bump version to 3.12.0"
    git push origin main
    ```
 2. Push the matching release tag:
    ```bash
-   git tag v3.7.0
-   git push origin v3.7.0
+   git tag v3.12.0
+   git push origin v3.12.0
    ```
 3. The CI pipeline checks `tag == package.json version` and fails with a clear error if they differ.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-metrics-viewer",
-      "version": "3.11.2",
+      "version": "3.11.3",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-browser": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.2",
+  "version": "3.11.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/services/user-metrics-aggregator.ts
+++ b/server/services/user-metrics-aggregator.ts
@@ -55,10 +55,16 @@ export function aggregateTeamMetrics(
     byDay.set(record.day, existing);
   }
 
+  const sortedDays = Array.from(byDay.keys()).sort();
+
+  // Pre-compute rolling window distinct-user sets per day so the day-level
+  // aggregator can reflect proper 7-day / 28-day windows (bug #410).
+  const rollingCounts = computeRollingWindowCounts(sortedDays, byDay);
+
   // Aggregate each day
-  const day_totals: ReportDayTotals[] = Array.from(byDay.entries())
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([day, records]) => aggregateDayRecords(day, records));
+  const day_totals: ReportDayTotals[] = sortedDays.map(day =>
+    aggregateDayRecords(day, byDay.get(day)!, rollingCounts.get(day)!)
+  );
 
   const allDays = day_totals.map(d => d.day);
   const report_start_day = allDays.length > 0 ? allDays[0]! : '';
@@ -78,8 +84,16 @@ export function aggregateTeamMetrics(
 
 /**
  * Aggregate a set of per-user records for a single day into one ReportDayTotals.
+ *
+ * Rolling-window active-user counts (weekly / monthly) are pre-computed at the
+ * team level in {@link computeRollingWindowCounts} and passed in via `rolling`,
+ * because a single day's records do not have visibility into other days.
  */
-function aggregateDayRecords(day: string, records: UserDayRecord[]): ReportDayTotals {
+function aggregateDayRecords(
+  day: string,
+  records: UserDayRecord[],
+  rolling: RollingWindowCounts,
+): ReportDayTotals {
   const activeUsers = records.length;
 
   return {
@@ -87,10 +101,10 @@ function aggregateDayRecords(day: string, records: UserDayRecord[]): ReportDayTo
     organization_id: records[0]?.organization_id ?? '',
     enterprise_id: records[0]?.enterprise_id ?? '',
     daily_active_users: activeUsers,
-    weekly_active_users: activeUsers,
-    monthly_active_users: activeUsers,
-    monthly_active_chat_users: records.filter(r => r.used_chat).length,
-    monthly_active_agent_users: records.filter(r => r.used_agent).length,
+    weekly_active_users: rolling.weekly_active_users,
+    monthly_active_users: rolling.monthly_active_users,
+    monthly_active_chat_users: rolling.monthly_active_chat_users,
+    monthly_active_agent_users: rolling.monthly_active_agent_users,
     user_initiated_interaction_count: sum(records, r => r.user_initiated_interaction_count),
     code_generation_activity_count: sum(records, r => r.code_generation_activity_count),
     code_acceptance_activity_count: sum(records, r => r.code_acceptance_activity_count),
@@ -104,6 +118,78 @@ function aggregateDayRecords(day: string, records: UserDayRecord[]): ReportDayTo
     totals_by_language_model: buildLanguageModelTotals(records),
     totals_by_model_feature: mergeModelFeatureTotals(records.flatMap(r => r.totals_by_model_feature ?? [])),
   };
+}
+
+// --- Rolling active-user window counts (bug #410) ---
+
+const WEEKLY_WINDOW_DAYS = 7;
+const MONTHLY_WINDOW_DAYS = 28;
+
+interface RollingWindowCounts {
+  weekly_active_users: number;
+  monthly_active_users: number;
+  monthly_active_chat_users: number;
+  monthly_active_agent_users: number;
+}
+
+/**
+ * For each day, compute distinct-user counts over the trailing 7-day and
+ * 28-day windows (including that day itself). Mirrors how GitHub computes
+ * `weekly_active_users` / `monthly_active_users` at the org level.
+ *
+ * Users are keyed case-insensitively by `user_login` (matching the login
+ * normalization used to filter team members).
+ */
+function computeRollingWindowCounts(
+  sortedDays: string[],
+  byDay: Map<string, UserDayRecord[]>,
+): Map<string, RollingWindowCounts> {
+  const result = new Map<string, RollingWindowCounts>();
+
+  for (const day of sortedDays) {
+    const weeklyCutoff = getDateNDaysAgo(day, WEEKLY_WINDOW_DAYS - 1);
+    const monthlyCutoff = getDateNDaysAgo(day, MONTHLY_WINDOW_DAYS - 1);
+
+    const weeklyUsers = new Set<string>();
+    const monthlyUsers = new Set<string>();
+    const monthlyChatUsers = new Set<string>();
+    const monthlyAgentUsers = new Set<string>();
+
+    for (const otherDay of sortedDays) {
+      if (otherDay > day || otherDay < monthlyCutoff) continue;
+      const records = byDay.get(otherDay) ?? [];
+      const inWeeklyWindow = otherDay >= weeklyCutoff;
+
+      for (const r of records) {
+        const login = r.user_login?.toLowerCase();
+        if (!login) continue;
+        monthlyUsers.add(login);
+        if (r.used_chat) monthlyChatUsers.add(login);
+        if (r.used_agent) monthlyAgentUsers.add(login);
+        if (inWeeklyWindow) weeklyUsers.add(login);
+      }
+    }
+
+    result.set(day, {
+      weekly_active_users: weeklyUsers.size,
+      monthly_active_users: monthlyUsers.size,
+      monthly_active_chat_users: monthlyChatUsers.size,
+      monthly_active_agent_users: monthlyAgentUsers.size,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Return the ISO date string N days before `dateStr` (UTC). Used to compute
+ * inclusive rolling-window cutoffs — e.g. `getDateNDaysAgo(d, 6)` gives the
+ * 7-day window start when combined with `d` itself.
+ */
+function getDateNDaysAgo(dateStr: string, n: number): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() - n);
+  return d.toISOString().split('T')[0]!;
 }
 
 // --- Merge helpers ---

--- a/tests/user-metrics-aggregator.spec.ts
+++ b/tests/user-metrics-aggregator.spec.ts
@@ -375,4 +375,136 @@ describe('aggregateTeamMetrics', () => {
     const result = aggregateTeamMetrics([noCompletionRecord], new Set(['alice']));
     expect(result.day_totals[0]!.totals_by_language_model).toHaveLength(0);
   });
+
+  // ── Bug #410: rolling active-user window counts ─────────────────────────────
+
+  describe('rolling active-user window counts (bug #410)', () => {
+    it('computes weekly_active_users as distinct users over the trailing 7-day window', () => {
+      // alice active on day 1, bob active on day 4, charlie active on day 7
+      // On day 7 the trailing 7-day window (day 1..day 7) should contain all 3 distinct users.
+      const records = [
+        makeUser('alice', 1, '2026-02-01'),
+        makeUser('bob', 2, '2026-02-04'),
+        makeUser('charlie', 3, '2026-02-07'),
+      ];
+      const result = aggregateTeamMetrics(records, new Set(['alice', 'bob', 'charlie']));
+
+      const day1 = result.day_totals.find(d => d.day === '2026-02-01')!;
+      const day7 = result.day_totals.find(d => d.day === '2026-02-07')!;
+
+      expect(day1.weekly_active_users).toBe(1);
+      expect(day1.daily_active_users).toBe(1);
+
+      // Day 7 window covers [2026-02-01, 2026-02-07] => 3 distinct users
+      expect(day7.weekly_active_users).toBe(3);
+      // Daily count is still just today's actives
+      expect(day7.daily_active_users).toBe(1);
+    });
+
+    it('excludes users active outside the trailing 7-day window from weekly_active_users', () => {
+      // alice active day 1, bob active day 10. On day 10 the 7-day window is [day 4..day 10],
+      // so alice should NOT be counted.
+      const records = [
+        makeUser('alice', 1, '2026-02-01'),
+        makeUser('bob', 2, '2026-02-10'),
+      ];
+      const result = aggregateTeamMetrics(records, new Set(['alice', 'bob']));
+
+      const day10 = result.day_totals.find(d => d.day === '2026-02-10')!;
+      expect(day10.weekly_active_users).toBe(1); // only bob
+    });
+
+    it('computes monthly_active_users as distinct users over the trailing 28-day window', () => {
+      // 4 users active on different days spanning ~3 weeks. On the last day, all 4 should
+      // fall within the 28-day window.
+      const records = [
+        makeUser('alice', 1, '2026-02-01'),
+        makeUser('bob', 2, '2026-02-08'),
+        makeUser('charlie', 3, '2026-02-15'),
+        makeUser('dave', 4, '2026-02-22'),
+      ];
+      const result = aggregateTeamMetrics(
+        records,
+        new Set(['alice', 'bob', 'charlie', 'dave'])
+      );
+
+      const lastDay = result.day_totals.find(d => d.day === '2026-02-22')!;
+      expect(lastDay.monthly_active_users).toBe(4);
+      expect(lastDay.daily_active_users).toBe(1);
+    });
+
+    it('excludes users active outside the trailing 28-day window from monthly_active_users', () => {
+      // alice active day 1, bob active day 30. Window on day 30 covers [day 3..day 30],
+      // so alice should NOT be counted.
+      const records = [
+        makeUser('alice', 1, '2026-02-01'),
+        makeUser('bob', 2, '2026-03-02'), // 29 days after
+      ];
+      const result = aggregateTeamMetrics(records, new Set(['alice', 'bob']));
+
+      const lastDay = result.day_totals[result.day_totals.length - 1]!;
+      expect(lastDay.day).toBe('2026-03-02');
+      expect(lastDay.monthly_active_users).toBe(1); // only bob
+    });
+
+    it('computes monthly_active_chat_users as distinct chat users over trailing 28-day window', () => {
+      const records = [
+        makeUser('alice', 1, '2026-02-01', { used_chat: true }),
+        makeUser('bob', 2, '2026-02-10', { used_chat: true }),
+        makeUser('charlie', 3, '2026-02-15', { used_chat: false }),
+        makeUser('alice', 1, '2026-02-20', { used_chat: true }), // repeated alice — still 1 distinct
+      ];
+      const result = aggregateTeamMetrics(
+        records,
+        new Set(['alice', 'bob', 'charlie'])
+      );
+
+      const lastDay = result.day_totals.find(d => d.day === '2026-02-20')!;
+      // alice + bob = 2 distinct chat users in window (charlie didn't use chat)
+      expect(lastDay.monthly_active_chat_users).toBe(2);
+    });
+
+    it('computes monthly_active_agent_users as distinct agent users over trailing 28-day window', () => {
+      const records = [
+        makeUser('alice', 1, '2026-02-01', { used_agent: true }),
+        makeUser('bob', 2, '2026-02-10', { used_agent: false }),
+        makeUser('charlie', 3, '2026-02-15', { used_agent: true }),
+        makeUser('charlie', 3, '2026-02-20', { used_agent: true }), // distinct = 1 for charlie
+      ];
+      const result = aggregateTeamMetrics(
+        records,
+        new Set(['alice', 'bob', 'charlie'])
+      );
+
+      const lastDay = result.day_totals.find(d => d.day === '2026-02-20')!;
+      // alice + charlie = 2 distinct agent users in window
+      expect(lastDay.monthly_active_agent_users).toBe(2);
+    });
+
+    it('counts each distinct user only once even if active on multiple days in the window', () => {
+      const records = [
+        makeUser('alice', 1, '2026-02-01'),
+        makeUser('alice', 1, '2026-02-02'),
+        makeUser('alice', 1, '2026-02-03'),
+      ];
+      const result = aggregateTeamMetrics(records, new Set(['alice']));
+      const day3 = result.day_totals.find(d => d.day === '2026-02-03')!;
+
+      expect(day3.weekly_active_users).toBe(1);
+      expect(day3.monthly_active_users).toBe(1);
+    });
+
+    it('handles case-insensitive user_login for distinct counting', () => {
+      const records = [
+        makeUser('Alice', 1, '2026-02-01'),
+        makeUser('ALICE', 1, '2026-02-02'), // same user, different casing
+      ];
+      const result = aggregateTeamMetrics(records, new Set(['alice']));
+      const day2 = result.day_totals.find(d => d.day === '2026-02-02')!;
+
+      // 'Alice' and 'ALICE' collapse to 1 distinct user
+      expect(day2.weekly_active_users).toBe(1);
+      expect(day2.monthly_active_users).toBe(1);
+    });
+  });
 });


### PR DESCRIPTION
The team aggregator previously set weekly_active_users, monthly_active_users, monthly_active_chat_users, and monthly_active_agent_users to the single-day active count, causing:
  - IDE active users KPI tile to undercount team users
  - WAU chart line to overlap DAU (no useful signal)
  - Chat/agent engagement to be under-reported
  - Agent adoption %% to be semantically incorrect / erratic

Fix by pre-computing distinct-user sets over the trailing 7-day and 28-day windows at the team level (where all days are visible), then passing the counts into aggregateDayRecords. Users are keyed case-insensitively.

Also add 8 regression tests covering weekly/monthly rolling counts, chat/agent breakdowns, exclusion of out-of-window users, and case-insensitive distinct counting.