### PR TITLE
fix(#412): allow selecting yesterday in date-range picker; clarify My Usage credit tiles

### DIFF
--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -69,6 +69,26 @@
             CLI activity and/or AI credit spend, which are reported separately.
           </v-alert>
 
+          <!-- Tab-level note: two independent data sources may report different
+               credit numbers because they use different time windows and pipelines.
+               See docs on the tiles themselves for source/window details. -->
+          <v-alert
+            v-if="data.spend"
+            type="info"
+            variant="tonal"
+            density="compact"
+            class="mx-3 mb-3"
+          >
+            <div class="text-body-2">
+              <strong>Two credit numbers, two sources.</strong>
+              The <em>AI credits used</em> tile above reflects the selected date
+              range and comes from the Copilot Metrics API. The
+              <em>Your AI credit spend</em> card is always <strong>month-to-date</strong>,
+              pulled live from the GitHub Billing API and independent of the
+              date-range picker — so the two values will not match exactly.
+            </div>
+          </v-alert>
+
           <v-row v-if="data.totals" dense class="px-3">
             <v-col cols="12" sm="6" md="3">
               <v-card variant="tonal" color="indigo" class="h-100">
@@ -106,7 +126,20 @@
             <v-col cols="12" sm="6" md="3">
               <v-card variant="tonal" color="cyan-darken-2" class="h-100">
                 <v-card-text>
-                  <div class="text-caption">AI credits used</div>
+                  <div class="text-caption d-flex align-center">
+                    AI credits used
+                    <v-tooltip location="top" max-width="280">
+                      <template #activator="{ props: tipProps }">
+                        <v-icon v-bind="tipProps" size="14" class="ml-1" color="cyan-darken-2">mdi-information-outline</v-icon>
+                      </template>
+                      <span>
+                        From the Copilot Metrics API (users report) — reflects
+                        the currently selected date range. May differ from the
+                        billing "Credits used" figure below, which is month-to-date
+                        and comes from a different pipeline.
+                      </span>
+                    </v-tooltip>
+                  </div>
                   <div class="text-h4 font-weight-bold">
                     <template v-if="typeof data.totals.ai_credits_used === 'number'">
                       {{ data.totals.ai_credits_used.toLocaleString(undefined, { maximumFractionDigits: 2 }) }}
@@ -114,6 +147,9 @@
                     <template v-else>
                       <span class="text-disabled" title="GitHub has not reported AI credits for this period">—</span>
                     </template>
+                  </div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    Metrics API · selected range
                   </div>
                 </v-card-text>
               </v-card>
@@ -170,11 +206,14 @@
               <v-card v-if="data.spend" variant="outlined" class="border-cyan">
                 <v-card-title class="text-subtitle-1 d-flex align-center">
                   <v-icon size="small" class="mr-1" color="cyan-darken-2">mdi-cash-multiple</v-icon>
-                  Your AI credit spend
+                  Your AI credit spend (month-to-date)
                   <span class="text-caption text-medium-emphasis ml-2">
                     {{ spendPeriodLabel }}<template v-if="data.spend.enterprise"> · enterprise {{ data.spend.enterprise }}</template>
                   </span>
                 </v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Source: GitHub Billing API (<code>ai_credit/usage</code>) · always current month · independent of the date-range picker above
+                </v-card-subtitle>
                 <v-card-text>
                   <v-row dense>
                     <v-col cols="12" sm="4">

--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -81,8 +81,8 @@
           >
             <div class="text-body-2">
               <strong>Two credit numbers, two sources.</strong>
-              The <em>AI credits used</em> tile above reflects the selected date
-              range and comes from the Copilot Metrics API. The
+              The credits KPI tile above reflects the selected date range and
+              comes from the Copilot Metrics API. The
               <em>Your AI credit spend</em> card is always <strong>month-to-date</strong>,
               pulled live from the GitHub Billing API and independent of the
               date-range picker — so the two values will not match exactly.

--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -81,8 +81,8 @@
           >
             <div class="text-body-2">
               <strong>Two credit numbers, two sources.</strong>
-              The credits KPI tile above reflects the selected date range and
-              comes from the Copilot Metrics API. The
+              The <em>AI credits used</em> tile above reflects the selected date
+              range and comes from the Copilot Metrics API. The
               <em>Your AI credit spend</em> card is always <strong>month-to-date</strong>,
               pulled live from the GitHub Billing API and independent of the
               date-range picker — so the two values will not match exactly.
@@ -126,7 +126,7 @@
             <v-col cols="12" sm="6" md="3">
               <v-card variant="tonal" color="cyan-darken-2" class="h-100">
                 <v-card-text>
-                  <div class="text-caption d-flex align-center">
+                  <div class="text-caption d-flex align-center" data-testid="my-usage-ai-credits-label">
                     AI credits used
                     <v-tooltip location="top" max-width="280">
                       <template #activator="{ props: tipProps }">

--- a/e2e-tests/pages/MyUsageTab.ts
+++ b/e2e-tests/pages/MyUsageTab.ts
@@ -18,7 +18,7 @@ export class MyUsageTab {
         this.activeDaysLabel = page.getByText("Active days", { exact: true });
         this.interactionsLabel = page.getByText("Interactions", { exact: true });
         this.acceptedLinesLabel = page.getByText("Accepted lines", { exact: true });
-        this.aiCreditsLabel = page.getByText("AI credits used", { exact: true });
+        this.aiCreditsLabel = page.getByTestId("my-usage-ai-credits-label");
         // The signed-in user heading — text-h6 inside MyUsageViewer.vue
         this.userLoginHeading = page.locator(".v-main .text-h6").first();
     }

--- a/server/api/data-range.ts
+++ b/server/api/data-range.ts
@@ -40,14 +40,19 @@ function toIsoDay(d: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+/** ISO YYYY-MM-DD for yesterday (UTC). Shared between live and historical modes. */
+function yesterdayIso(): string {
+  const now = new Date();
+  return toIsoDay(new Date(now.getTime() - 24 * 60 * 60 * 1000));
+}
+
 /** Live-mode default window: the 28 days ending yesterday. */
 function liveWindow(): { earliest: string; latest: string } {
-  const now = new Date();
-  // Yesterday — GitHub metrics have ~1-day lag, today is not ready yet
-  const latest = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  const latestIso = yesterdayIso();
+  const latest = new Date(`${latestIso}T00:00:00Z`);
   // 28 days inclusive ending yesterday → start = latest - 27d
   const earliest = new Date(latest.getTime() - 27 * 24 * 60 * 60 * 1000);
-  return { earliest: toIsoDay(earliest), latest: toIsoDay(latest) };
+  return { earliest: toIsoDay(earliest), latest: latestIso };
 }
 
 /** Extract every `day` (YYYY-MM-DD) field from a mock JSON `day_totals` array. */
@@ -119,7 +124,16 @@ export default defineEventHandler(async (event): Promise<DataRange> => {
   // sync pipeline regardless of the mode label.
   try {
     const stored = await historicalRange(scope, identifier);
-    if (stored) return { ...stored, mode: 'historical' };
+    if (stored) {
+      // Bug #412: the sync container ingests once/day, so MAX(metrics_date)
+      // can lag 1–2 days behind the calendar. Meanwhile the billing tile on
+      // My Usage pulls live from GitHub and already shows yesterday's spend.
+      // Widen `latest` to at least yesterday so the date picker doesn't
+      // block users from selecting a day that the billing endpoint (and the
+      // live-API fallback in my-usage / metrics handlers) will happily serve.
+      const widenedLatest = stored.latest < yesterdayIso() ? yesterdayIso() : stored.latest;
+      return { earliest: stored.earliest, latest: widenedLatest, mode: 'historical' };
+    }
     logger.info('[data-range] No stored data yet, falling back to live window');
   } catch (err) {
     logger.warn('[data-range] Storage lookup failed, falling back to live window:', err);

--- a/tests/data-range.spec.ts
+++ b/tests/data-range.spec.ts
@@ -80,26 +80,33 @@ describe('/api/data-range handler', () => {
   })
 
   it('returns DB-derived range when storage has data (no env flag required)', async () => {
+    // Use a "latest" that is >= yesterday so the widening in bug #412 is a no-op
+    // and this test can assert the raw DB output.
+    const now = new Date()
+    const today = now.toISOString().slice(0, 10)
     mockPoolQuery.mockResolvedValue({
-      rows: [{ earliest: '2026-01-15', latest: '2026-06-14' }],
+      rows: [{ earliest: '2026-01-15', latest: today }],
     })
 
     const { default: handler } = await import('../server/api/data-range')
     const result = await handler(makeEvent() as any)
 
-    expect(result).toEqual({ earliest: '2026-01-15', latest: '2026-06-14', mode: 'historical' })
+    expect(result).toEqual({ earliest: '2026-01-15', latest: today, mode: 'historical' })
   })
 
   it('historical mode: returns DB-derived earliest/latest', async () => {
     process.env.DATABASE_URL = 'postgres://test'
+    // Use a "latest" that is >= yesterday so the widening in bug #412 is a no-op.
+    const now = new Date()
+    const today = now.toISOString().slice(0, 10)
     mockPoolQuery.mockResolvedValue({
-      rows: [{ earliest: '2026-01-15', latest: '2026-06-14' }],
+      rows: [{ earliest: '2026-01-15', latest: today }],
     })
 
     const { default: handler } = await import('../server/api/data-range')
     const result = await handler(makeEvent() as any)
 
-    expect(result).toEqual({ earliest: '2026-01-15', latest: '2026-06-14', mode: 'historical' })
+    expect(result).toEqual({ earliest: '2026-01-15', latest: today, mode: 'historical' })
     expect(mockPoolQuery).toHaveBeenCalledTimes(1)
     // organization (not the team-* variant) is forwarded to the query
     const [, params] = mockPoolQuery.mock.calls[0]!
@@ -109,8 +116,10 @@ describe('/api/data-range handler', () => {
   it('historical mode: strips team- prefix to base scope', async () => {
     process.env.DATABASE_URL = 'postgres://test'
     setQuery({ scope: 'team-organization', githubOrg: 'test-org', githubTeam: 'a-team' })
+    const now = new Date()
+    const today = now.toISOString().slice(0, 10)
     mockPoolQuery.mockResolvedValue({
-      rows: [{ earliest: '2026-01-15', latest: '2026-06-14' }],
+      rows: [{ earliest: '2026-01-15', latest: today }],
     })
 
     const { default: handler } = await import('../server/api/data-range')
@@ -140,5 +149,46 @@ describe('/api/data-range handler', () => {
     const result = await handler(makeEvent() as any)
 
     expect(result.mode).toBe('live')
+  })
+
+  // ── Bug #412: picker "To Date" was 1-2 days behind yesterday ────────────────
+  // Historical MAX(metrics_date) lags behind the calendar because the sync
+  // container only ingests once/day. The billing tile pulls live from GitHub
+  // so it can show yesterday even when the picker won't let you select it.
+  // Fix: widen `latest` to at least yesterday (UTC).
+
+  it('historical mode: extends latest to yesterday when DB max lags behind', async () => {
+    process.env.DATABASE_URL = 'postgres://test'
+    // Simulate a DB whose most recent row is 5 days old.
+    const now = new Date()
+    const fiveDaysAgo = new Date(now.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ earliest: '2026-01-15', latest: fiveDaysAgo }],
+    })
+
+    const { default: handler } = await import('../server/api/data-range')
+    const result = await handler(makeEvent() as any)
+
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
+    expect(result.mode).toBe('historical')
+    expect(result.earliest).toBe('2026-01-15') // honest DB earliest
+    expect(result.latest).toBe(yesterday)      // widened to yesterday
+  })
+
+  it('historical mode: keeps DB latest when it is already past yesterday', async () => {
+    process.env.DATABASE_URL = 'postgres://test'
+    // A DB with data through today (or later — e.g. clock skew, timezones)
+    // should not be truncated back to yesterday.
+    const now = new Date()
+    const today = now.toISOString().slice(0, 10)
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ earliest: '2026-01-15', latest: today }],
+    })
+
+    const { default: handler } = await import('../server/api/data-range')
+    const result = await handler(makeEvent() as any)
+
+    expect(result.mode).toBe('historical')
+    expect(result.latest).toBe(today)
   })
 })


### PR DESCRIPTION
Fixes #412.

## Problem
Reporter observed that the date-range picker's max was `6 July` while the "current month AI credit spend" tile already showed data through `7 July`, so the picker refused to select a day the tile was already reporting.

## Root cause
`/api/data-range` in historical mode returned `latest = MAX(metrics_date)` from the DB. The sync container ingests once/day so that MAX lags 1-2 days behind the calendar. Meanwhile the billing tile hits GitHub's `/enterprises/.../ai_credit/usage` endpoint live, which is fresher — creating the visible inconsistency.

## Fix (`server/api/data-range.ts`)
Widen historical `latest` to `max(MAX(metrics_date), yesterday_UTC)` so the picker always allows selecting up to yesterday. Metrics handlers that don't have DB data for the widened day already fall back to the live API (e.g. `my-usage.get.ts:234-238`). Extracted a shared `yesterdayIso()` helper so live-mode and historical-mode share one definition.

## UX clarification (`app/components/MyUsageViewer.vue`)
The two "credit" numbers on My Usage legitimately differ because they come from two independent APIs with different time windows. That distinction was invisible in the UI. Added:

1. **Tab-level info banner** explaining the two sources / two windows.
2. **"AI credits used" tile**: tooltip + subtitle identifying source and window (`Metrics API · selected range`).
3. **"Your AI credit spend" card**: renamed title to include `(month-to-date)` and added a subtitle citing the Billing API endpoint and that it is independent of the date-range picker.

## Testing (TDD)
- Wrote 2 new failing tests first (`tests/data-range.spec.ts`) reproducing the widening behavior, then applied the fix.
- Updated 2 existing tests that hardcoded stale dates (`2026-06-14`) to use dates guaranteed to be >= yesterday so the widening is a documented no-op.
- Full suite: **736/736 tests pass**.

## Screens the fix affects
- Date-range picker on any page (max is widened to yesterday)
- My Usage tab: two new hints + renamed spend card title