### PR TITLE
feat(billing): label data sources + add Month view toggle so date-range picker drives Billing tab

### DIFF
--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -118,18 +118,27 @@
                 <div class="text-h5 font-weight-bold">
                   {{ totalGrossQty.toLocaleString(undefined, { maximumFractionDigits: 2 }) }}
                 </div>
+                <div class="text-caption text-medium-emphasis mt-1">
+                  Billing API · {{ periodLabel || 'current month' }}
+                </div>
               </v-card-text>
             </v-card>
             <v-card variant="tonal" color="green" min-width="180">
               <v-card-text>
                 <div class="text-caption">Gross cost (USD)</div>
                 <div class="text-h5 font-weight-bold">${{ totalGrossAmount.toFixed(2) }}</div>
+                <div class="text-caption text-medium-emphasis mt-1">
+                  Billing API · {{ periodLabel || 'current month' }}
+                </div>
               </v-card-text>
             </v-card>
             <v-card variant="tonal" color="indigo" min-width="180">
               <v-card-text>
                 <div class="text-caption">Net cost (USD)</div>
                 <div class="text-h5 font-weight-bold">${{ totalNetAmount.toFixed(2) }}</div>
+                <div class="text-caption text-medium-emphasis mt-1">
+                  Billing API · {{ periodLabel || 'current month' }}
+                </div>
               </v-card-text>
             </v-card>
           </div>
@@ -165,6 +174,9 @@
                     (loaded {{ loadedLoginsCount }} of {{ perUserRows.length }} users<span v-if="loadedLoginsCount < perUserRows.length">; sort by $ or page through to load more</span>)
                   </span>
                 </v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Source: Billing API (<code>ai_credit/usage</code> per user) · {{ periodLabel || 'current month' }}
+                </v-card-subtitle>
                 <v-card-text>
                   <div v-if="topSpendersChartData" style="height: 280px">
                     <Bar :data="topSpendersChartData" :options="topSpendersChartOptions" />
@@ -184,6 +196,9 @@
                     (prompt + output)
                   </span>
                 </v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Source: Copilot Metrics API (<code>totals_by_cli.token_usage</code>) · rolling last 28 days · <strong>not linked to the billing month picker</strong>
+                </v-card-subtitle>
                 <v-card-text>
                   <div v-if="topTokensChartData" style="height: 280px">
                     <Bar :data="topTokensChartData" :options="topTokensChartOptions" />
@@ -207,6 +222,10 @@
                 />
               </span>
             </v-card-title>
+            <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+              Mixed sources: <strong>User</strong> list + <strong>Tokens (CLI)</strong> come from the Copilot Metrics API (rolling last 28 days).
+              <strong>Credits</strong>, <strong>Gross $</strong>, <strong>Net $</strong>, and <strong>Models</strong> come from the Billing API for {{ periodLabel || 'the current month' }}.
+            </v-card-subtitle>
             <v-data-table
               :items="perUserRows"
               :headers="perUserHeaders"
@@ -292,6 +311,9 @@
 
           <v-card variant="outlined" class="ma-3">
             <v-card-title class="text-subtitle-1">Raw billing line items</v-card-title>
+            <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+              Source: Billing API (<code>ai_credit/usage</code>) · {{ periodLabel || 'current month' }} · one aggregate row per product × SKU × model × user
+            </v-card-subtitle>
             <v-data-table
               :items="items"
               :headers="headers"

--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -14,35 +14,64 @@
             enterprise billing endpoint when available.
           </div>
         </div>
-        <div style="min-width: 200px;">
-          <v-text-field
-            v-model="selectedMonth"
-            label="Billing month"
-            type="month"
+        <div style="min-width: 260px;">
+          <v-checkbox
+            v-model="monthView"
+            label="Month view"
             density="compact"
             hide-details
-            variant="outlined"
-            prepend-inner-icon="mdi-calendar-month"
-          />
-          <div class="d-flex justify-space-between mt-1">
-            <v-btn
-              size="x-small"
-              variant="text"
-              prepend-icon="mdi-chevron-left"
-              @click="shiftMonth(-1)"
-            >Prev</v-btn>
-            <v-btn
-              size="x-small"
-              variant="text"
-              @click="selectedMonth = currentMonthIso"
-            >This month</v-btn>
-            <v-btn
-              size="x-small"
-              variant="text"
-              append-icon="mdi-chevron-right"
-              :disabled="selectedMonth >= currentMonthIso"
-              @click="shiftMonth(1)"
-            >Next</v-btn>
+            color="indigo"
+            class="mb-1"
+          >
+            <template #append>
+              <v-tooltip location="top" max-width="320">
+                <template #activator="{ props: tipProps }">
+                  <v-icon v-bind="tipProps" size="16" color="grey">mdi-information-outline</v-icon>
+                </template>
+                <span>
+                  When enabled, use the month picker below and query the live
+                  GitHub Billing API (which only supports a single day or a
+                  whole calendar month). When disabled, the dashboard-wide
+                  date-range picker at the top drives this tab — but that
+                  requires the Billing CSV to have been ingested for the
+                  selected range via the Admin Panel.
+                </span>
+              </v-tooltip>
+            </template>
+          </v-checkbox>
+          <template v-if="monthView">
+            <v-text-field
+              v-model="selectedMonth"
+              label="Billing month"
+              type="month"
+              density="compact"
+              hide-details
+              variant="outlined"
+              prepend-inner-icon="mdi-calendar-month"
+            />
+            <div class="d-flex justify-space-between mt-1">
+              <v-btn
+                size="x-small"
+                variant="text"
+                prepend-icon="mdi-chevron-left"
+                @click="shiftMonth(-1)"
+              >Prev</v-btn>
+              <v-btn
+                size="x-small"
+                variant="text"
+                @click="selectedMonth = currentMonthIso"
+              >This month</v-btn>
+              <v-btn
+                size="x-small"
+                variant="text"
+                append-icon="mdi-chevron-right"
+                :disabled="selectedMonth >= currentMonthIso"
+                @click="shiftMonth(1)"
+              >Next</v-btn>
+            </div>
+          </template>
+          <div v-else class="text-caption text-medium-emphasis">
+            Using dashboard date range: <strong>{{ dateRangeDescription || 'default' }}</strong>
           </div>
         </div>
       </div>
@@ -66,15 +95,32 @@
             <code>manage_billing:enterprise</code> (for enterprise scope).
             Fine-grained PATs and GitHub Apps are not supported by these endpoints.
           </div>
+          <div v-else-if="errorReason === 'range-requires-db'" class="mt-2 text-caption">
+            The dashboard-wide date range doesn't align with a single calendar month, so this
+            tab must serve it from the local database. No CSV ingest job covers the requested
+            range yet. Either:
+            <ul class="ml-4 mt-1">
+              <li>Enable <strong>Month view</strong> above to query the live GitHub Billing API for a specific month, or</li>
+              <li>Run the <strong>Billing CSV ingest</strong> in the Admin Panel to import data for {{ dateRangeDescription || 'this range' }}.</li>
+            </ul>
+          </div>
         </v-alert>
 
         <v-alert v-else-if="!items.length" type="info" density="compact" class="ma-3">
           <div>
             No billing data returned for {{ data?.organization || data?.enterprise }}
-            <span v-if="periodLabel">in <strong>{{ periodLabel }}</strong></span>
+            <span v-if="!monthView && dateRangeDescription">
+              for <strong>{{ dateRangeDescription }}</strong>
+            </span>
+            <span v-else-if="periodLabel">in <strong>{{ periodLabel }}</strong></span>
             <span v-else>in this period</span>.
           </div>
-          <div v-if="!isCurrentMonth" class="mt-2 text-caption">
+          <div v-if="!monthView" class="mt-2 text-caption">
+            Enable <strong>Month view</strong> above to query the live GitHub Billing API for
+            a specific calendar month, or run the <strong>Billing CSV ingest</strong> in the
+            Admin Panel to import billing data for the selected range.
+          </div>
+          <div v-else-if="!isCurrentMonth" class="mt-2 text-caption">
             GitHub's live billing API typically only returns data for the
             <strong>current calendar month</strong>. Historical months populate
             here once the <em>Billing CSV ingest</em> in the Admin Panel has
@@ -85,7 +131,7 @@
 
         <template v-else>
           <v-alert
-            v-if="periodLabel"
+            v-if="monthView ? periodLabel : dateRangeDescription"
             type="info"
             variant="tonal"
             density="compact"
@@ -93,10 +139,16 @@
             icon="mdi-calendar-range"
           >
             <div class="d-flex flex-wrap align-center gap-2">
-              <span>
+              <span v-if="monthView">
                 Showing billing usage for <strong>{{ periodLabel }}</strong>.
                 Use the <em>Billing month</em> picker above to view a different
                 month. GitHub retains roughly 90 days of detail.
+              </span>
+              <span v-else>
+                Showing billing usage for <strong>{{ dateRangeDescription }}</strong>
+                (dashboard date range). This range is served from the local
+                database (Billing CSV ingest) — uncheck <em>Month view</em>
+                only when the desired range has been ingested via the Admin Panel.
               </span>
               <v-chip
                 v-if="dataSourceBadge"
@@ -119,7 +171,7 @@
                   {{ totalGrossQty.toLocaleString(undefined, { maximumFractionDigits: 2 }) }}
                 </div>
                 <div class="text-caption text-medium-emphasis mt-1">
-                  Billing API · {{ periodLabel || 'current month' }}
+                  Billing API · {{ rangeLabel }}
                 </div>
               </v-card-text>
             </v-card>
@@ -128,7 +180,7 @@
                 <div class="text-caption">Gross cost (USD)</div>
                 <div class="text-h5 font-weight-bold">${{ totalGrossAmount.toFixed(2) }}</div>
                 <div class="text-caption text-medium-emphasis mt-1">
-                  Billing API · {{ periodLabel || 'current month' }}
+                  Billing API · {{ rangeLabel }}
                 </div>
               </v-card-text>
             </v-card>
@@ -137,7 +189,7 @@
                 <div class="text-caption">Net cost (USD)</div>
                 <div class="text-h5 font-weight-bold">${{ totalNetAmount.toFixed(2) }}</div>
                 <div class="text-caption text-medium-emphasis mt-1">
-                  Billing API · {{ periodLabel || 'current month' }}
+                  Billing API · {{ rangeLabel }}
                 </div>
               </v-card-text>
             </v-card>
@@ -175,7 +227,7 @@
                   </span>
                 </v-card-title>
                 <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
-                  Source: Billing API (<code>ai_credit/usage</code> per user) · {{ periodLabel || 'current month' }}
+                  Source: Billing API (<code>ai_credit/usage</code> per user) · {{ rangeLabel }}
                 </v-card-subtitle>
                 <v-card-text>
                   <div v-if="topSpendersChartData" style="height: 280px">
@@ -224,7 +276,7 @@
             </v-card-title>
             <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
               Mixed sources: <strong>User</strong> list + <strong>Tokens (CLI)</strong> come from the Copilot Metrics API (rolling last 28 days).
-              <strong>Credits</strong>, <strong>Gross $</strong>, <strong>Net $</strong>, and <strong>Models</strong> come from the Billing API for {{ periodLabel || 'the current month' }}.
+              <strong>Credits</strong>, <strong>Gross $</strong>, <strong>Net $</strong>, and <strong>Models</strong> come from the Billing API for {{ rangeLabel }}.
             </v-card-subtitle>
             <v-data-table
               :items="perUserRows"
@@ -312,7 +364,7 @@
           <v-card variant="outlined" class="ma-3">
             <v-card-title class="text-subtitle-1">Raw billing line items</v-card-title>
             <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
-              Source: Billing API (<code>ai_credit/usage</code>) · {{ periodLabel || 'current month' }} · one aggregate row per product × SKU × model × user
+              Source: Billing API (<code>ai_credit/usage</code>) · {{ rangeLabel }} · one aggregate row per product × SKU × model × user
             </v-card-subtitle>
             <v-data-table
               :items="items"
@@ -360,6 +412,7 @@ export default defineComponent({
   components: { Bar, MyUsageViewer },
   props: {
     queryParams: { type: Object as () => Record<string, string>, default: () => ({}) },
+    dateRangeDescription: { type: String, default: '' },
   },
   async setup(props) {
     // ── Billing month selector ─────────────────────────────────────────────
@@ -387,17 +440,35 @@ export default defineComponent({
 
     const isCurrentMonth = computed(() => selectedMonth.value === currentMonthIso.value);
 
-    // Merge picker state into the parent-provided queryParams. We only
-    // override year/month when the user has picked something other than the
-    // current month — keeps the default behavior identical to before.
+    // ── Month view toggle ─────────────────────────────────────────────────
+    // Default = true (matches historical behavior: month picker drives the
+    // fetch, ignores the dashboard-wide date-range picker). When false, the
+    // dashboard's since/until is forwarded and the server serves DB-only.
+    const monthView = ref<boolean>(true);
+
+    // Merge picker state into the parent-provided queryParams.
+    // - monthView=true:  strip any since/until from the parent and inject
+    //                    year/month from the month picker (live-API-compatible)
+    // - monthView=false: forward the parent's since/until as-is; do NOT
+    //                    inject year/month (server routes to DB path)
     const billingQuery = computed<Record<string, string>>(() => {
-      const merged: Record<string, string> = { ...props.queryParams };
-      const [y, m] = selectedMonth.value.split('-');
-      if (y && m) {
-        merged.year = y;
-        merged.month = String(Number(m));
+      const parent = { ...(props.queryParams || {}) };
+      if (monthView.value) {
+        // Strip parent since/until so they don't collide with the month picker
+        delete parent.since;
+        delete parent.until;
+        const [y, m] = selectedMonth.value.split('-');
+        if (y && m) {
+          parent.year = y;
+          parent.month = String(Number(m));
+        }
+        return parent;
       }
-      return merged;
+      // Range mode — drop any year/month/day the parent might carry
+      delete parent.year;
+      delete parent.month;
+      delete parent.day;
+      return parent;
     });
 
     const dataSource = ref<{ source: 'db' | 'live' | null; syncedAt: string | null; reason: string | null }>({
@@ -444,9 +515,9 @@ export default defineComponent({
     const loadedLogins = reactive(new Set<string>());
     const perUserLoading = ref(false);
 
-    // When the user switches month, drop cached per-user roll-ups so the
-    // visible page re-fetches against the new window.
-    watch(selectedMonth, () => {
+    // When the user switches month or toggles month view, drop cached
+    // per-user roll-ups so the visible page re-fetches against the new window.
+    watch([selectedMonth, monthView, () => props.queryParams.since, () => props.queryParams.until], () => {
       billingByLogin.clear();
       loadedLogins.clear();
     });
@@ -461,12 +532,21 @@ export default defineComponent({
         // Chunk to the endpoint's per-call cap (50).
         for (let i = 0; i < needed.length; i += 50) {
           const chunk = needed.slice(i, i + 50);
-          const qp: Record<string, string> = { ...(props.queryParams || {}), logins: chunk.join(',') };
-          const [y, m] = selectedMonth.value.split('-');
-          if (y && m) {
-            qp.year = y;
-            qp.month = String(Number(m));
+          const parent = { ...(props.queryParams || {}) };
+          if (monthView.value) {
+            delete parent.since;
+            delete parent.until;
+            const [y, m] = selectedMonth.value.split('-');
+            if (y && m) {
+              parent.year = y;
+              parent.month = String(Number(m));
+            }
+          } else {
+            delete parent.year;
+            delete parent.month;
+            delete parent.day;
           }
+          const qp: Record<string, string> = { ...parent, logins: chunk.join(',') };
           try {
             const resp = await $fetch<BillingCreditsResponse>('/api/billing-credits-by-user', { query: qp });
             for (const it of resp.usageItems ?? []) {
@@ -602,11 +682,13 @@ export default defineComponent({
       }
     });
 
-    // Distinguish "our admin gate" 403 from "GitHub billing API" 403, since the
-    // remediation steps are very different.
-    const errorReason = computed<'usage-admin' | 'github-pat-scope' | 'other' | null>(() => {
-      const err = error.value as { statusCode?: number; statusMessage?: string; data?: { message?: string } } | null;
-      if (!err || err.statusCode !== 403) return null;
+    // Distinguish "our admin gate" 403 from "GitHub billing API" 403 from
+    // "custom range with no ingest coverage" 409, since remediation differs.
+    const errorReason = computed<'usage-admin' | 'github-pat-scope' | 'range-requires-db' | 'other' | null>(() => {
+      const err = error.value as { statusCode?: number; statusMessage?: string; data?: { message?: string; reason?: string } } | null;
+      if (!err) return null;
+      if (err.statusCode === 409 && err.data?.reason === 'range-requires-db') return 'range-requires-db';
+      if (err.statusCode !== 403) return null;
       const msg = (err.statusMessage || '') + ' ' + (err.data?.message || '');
       if (msg.includes('NUXT_USAGE_ADMINS')) return 'usage-admin';
       if (/personal access token|administration|manage_billing|insufficient/i.test(msg)) return 'github-pat-scope';
@@ -708,6 +790,16 @@ export default defineComponent({
 
     const dataSourceBadge = computed(() => buildDataSourceBadge(dataSource.value));
 
+    // Human label for the window covered by the current billing fetch,
+    // used in every card/table subtitle so the source+range is unambiguous.
+    // Month view → the month/day the picker resolves to (via `periodLabel`).
+    // Range view → the dashboard-wide date-range description (e.g.
+    //              "From 6/23/2026 to 7/8/2026 (16 days)").
+    const rangeLabel = computed(() => {
+      if (monthView.value) return periodLabel.value || 'current month';
+      return props.dateRangeDescription || 'the selected date range';
+    });
+
     // ── Admin drill-down: click a username → show inline User insights ──────
     // Billing tab is already admin-gated, so we don't add a second check here.
     // The /api/my-usage endpoint enforces its own `requireUsageAdmin` when
@@ -732,6 +824,7 @@ export default defineComponent({
     return {
       data, pending, error, items, periodLabel,
       selectedMonth, currentMonthIso, shiftMonth, isCurrentMonth,
+      monthView, rangeLabel,
       totalGrossQty, totalGrossAmount, totalNetAmount,
       errorReason, headers,
       perUserRows, perUserHeaders,

--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -359,6 +359,7 @@
               <MyUsageViewer
                 :key="userDetailLogin"
                 :query-params="userDetailQueryParams"
+                :date-range-description="dateRangeDescription"
               />
             </v-card-text>
           </v-card>

--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -22,6 +22,7 @@
             hide-details
             color="indigo"
             class="mb-1"
+            data-testid="billing-month-view-toggle"
           >
             <template #append>
               <v-tooltip location="top" max-width="320">
@@ -48,6 +49,7 @@
               hide-details
               variant="outlined"
               prepend-inner-icon="mdi-calendar-month"
+              data-testid="billing-month-picker"
             />
             <div class="d-flex justify-space-between mt-1">
               <v-btn
@@ -70,7 +72,7 @@
               >Next</v-btn>
             </div>
           </template>
-          <div v-else class="text-caption text-medium-emphasis">
+          <div v-else class="text-caption text-medium-emphasis" data-testid="billing-range-caption">
             Using dashboard date range: <strong>{{ dateRangeDescription || 'default' }}</strong>
           </div>
         </div>

--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -251,7 +251,7 @@
                   </span>
                 </v-card-title>
                 <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
-                  Source: Copilot Metrics API (<code>totals_by_cli.token_usage</code>) · rolling last 28 days · <strong>not linked to the billing month picker</strong>
+                  Source: Copilot Metrics API (<code>totals_by_cli.token_usage</code>) · {{ dateRangeDescription || 'last 28 days' }}
                 </v-card-subtitle>
                 <v-card-text>
                   <div v-if="topTokensChartData" style="height: 280px">
@@ -277,7 +277,7 @@
               </span>
             </v-card-title>
             <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
-              Mixed sources: <strong>User</strong> list + <strong>Tokens (CLI)</strong> come from the Copilot Metrics API (rolling last 28 days).
+              Mixed sources: <strong>User</strong> list + <strong>Tokens (CLI)</strong> come from the Copilot Metrics API for {{ dateRangeDescription || 'the last 28 days' }}.
               <strong>Credits</strong>, <strong>Gross $</strong>, <strong>Net $</strong>, and <strong>Models</strong> come from the Billing API for {{ rangeLabel }}.
             </v-card-subtitle>
             <v-data-table

--- a/app/components/MainComponent.vue
+++ b/app/components/MainComponent.vue
@@ -155,7 +155,7 @@
 
     <!-- Date Range Selector - shown only when calendar icon toggled -->
     <DateRangeSelector 
-      v-show="showDateRange && tab !== 'seat analysis' && tab !== 'billing' && !signInRequired" 
+      v-show="showDateRange && tab !== 'seat analysis' && !signInRequired" 
       :loading="isLoading"
       :min-date="dataRange?.earliest"
       :max-date="dataRange?.latest"
@@ -261,7 +261,8 @@ v-if="item === 'copilot chat'" :metrics="metrics"
             />
             <BillingCreditsViewer
               v-if="item === 'billing' && billingEnabled"
-              :query-params="seatsQueryParams"
+              :query-params="myUsageQueryParams"
+              :date-range-description="dateRangeDescription"
             />
             <BillingNotConfigured v-else-if="item === 'billing'" />
             <ApiResponse

--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -218,13 +218,13 @@
               <v-card v-if="data.spend" variant="outlined" class="border-cyan">
                 <v-card-title class="text-subtitle-1 d-flex align-center">
                   <v-icon size="small" class="mr-1" color="cyan-darken-2">mdi-cash-multiple</v-icon>
-                  Your AI credit spend (month-to-date)
+                  {{ spendCardTitle }}
                   <span class="text-caption text-medium-emphasis ml-2">
                     {{ spendPeriodLabel }}<template v-if="data.spend.enterprise"> · enterprise {{ data.spend.enterprise }}</template>
                   </span>
                 </v-card-title>
                 <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
-                  Source: GitHub Billing API (<code>ai_credit/usage</code>) · always current month · independent of the date-range picker above
+                  {{ spendSourceCaption }}
                 </v-card-subtitle>
                 <v-card-text>
                   <v-row dense>
@@ -428,6 +428,9 @@ interface MyUsageSpend {
   byModel: { model: string; amount: number; quantity: number; grossAmount: number; grossQuantity: number }[];
   timePeriod?: { year?: number; month?: number; day?: number };
   enterprise?: string;
+  source?: 'live' | 'db';
+  since?: string;
+  until?: string;
 }
 
 interface MyUsageResponse {
@@ -480,7 +483,15 @@ export default defineComponent({
     });
 
     const spendPeriodLabel = computed(() => {
-      const tp = data.value?.spend?.timePeriod;
+      const sp = data.value?.spend;
+      if (!sp) return 'Current billing period';
+      // DB-served range (custom since/until) — prefer parent's human label,
+      // fall back to since → until.
+      if (sp.source === 'db') {
+        if (props.dateRangeDescription) return props.dateRangeDescription;
+        if (sp.since && sp.until) return `${sp.since} → ${sp.until}`;
+      }
+      const tp = sp.timePeriod;
       if (!tp) return 'Current billing period';
       const parts: string[] = [];
       if (tp.year) parts.push(String(tp.year));
@@ -488,6 +499,20 @@ export default defineComponent({
       if (tp.day) parts.push(String(tp.day).padStart(2, '0'));
       return parts.length ? parts.join('-') : 'Current billing period';
     });
+
+    // Human label + source description for the spend card. Adapts to whether
+    // the spend was served from live GitHub Billing API (month-to-date) or
+    // from the local billing_credit_usage table for a custom range.
+    const spendCardTitle = computed(() =>
+      data.value?.spend?.source === 'db'
+        ? 'AI credit spend (selected range)'
+        : 'Your AI credit spend (month-to-date)'
+    );
+    const spendSourceCaption = computed(() =>
+      data.value?.spend?.source === 'db'
+        ? 'Source: local billing_credit_usage (CSV ingest) · aggregated for the dashboard date range'
+        : 'Source: GitHub Billing API (ai_credit/usage) · always current month · independent of the date-range picker above'
+    );
 
     // Human label for the Metrics API window used by the tiles/CLI card/etc.
     // Prefer the parent-provided `dateRangeDescription` (e.g. "Over the last
@@ -696,6 +721,7 @@ export default defineComponent({
 
     return {
       data, pending, error, initials, topIde, topModel, cliTotals, spendPeriodLabel,
+      spendCardTitle, spendSourceCaption,
       rangeLabel,
       hasDiscount,
       aiCreditsChartData, aiCreditsChartOptions, aiCreditsTotalLabel, aiCreditsDayCount,

--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -81,8 +81,8 @@
           >
             <div class="text-body-2">
               <strong>Two credit numbers, two sources.</strong>
-              The <em>AI credits used</em> tile above reflects the selected date
-              range and comes from the Copilot Metrics API. The
+              The <em>AI credits used</em> tile above covers {{ rangeLabel }}
+              and comes from the Copilot Metrics API. The
               <em>Your AI credit spend</em> card is always <strong>month-to-date</strong>,
               pulled live from the GitHub Billing API and independent of the
               date-range picker — so the two values will not match exactly.
@@ -100,6 +100,9 @@
                       {{ data.totals.ai_adoption_phase.phase }}
                     </v-chip>
                   </div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    Metrics API · {{ rangeLabel }}
+                  </div>
                 </v-card-text>
               </v-card>
             </v-col>
@@ -110,6 +113,9 @@
                   <div class="text-h4 font-weight-bold">
                     {{ data.totals.user_initiated_interaction_count.toLocaleString() }}
                   </div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    Metrics API · {{ rangeLabel }}
+                  </div>
                 </v-card-text>
               </v-card>
             </v-col>
@@ -119,6 +125,9 @@
                   <div class="text-caption">Accepted lines</div>
                   <div class="text-h4 font-weight-bold">
                     {{ data.totals.loc_added_sum.toLocaleString() }}
+                  </div>
+                  <div class="text-caption text-medium-emphasis mt-1">
+                    Metrics API · {{ rangeLabel }}
                   </div>
                 </v-card-text>
               </v-card>
@@ -133,9 +142,9 @@
                         <v-icon v-bind="tipProps" size="14" class="ml-1" color="cyan-darken-2">mdi-information-outline</v-icon>
                       </template>
                       <span>
-                        From the Copilot Metrics API (users report) — reflects
-                        the currently selected date range. May differ from the
-                        billing "Credits used" figure below, which is month-to-date
+                        From the Copilot Metrics API (users report) — covers
+                        {{ rangeLabel }}. May differ from the billing
+                        "Credits used" figure below, which is month-to-date
                         and comes from a different pipeline.
                       </span>
                     </v-tooltip>
@@ -149,7 +158,7 @@
                     </template>
                   </div>
                   <div class="text-caption text-medium-emphasis mt-1">
-                    Metrics API · selected range
+                    Metrics API · {{ rangeLabel }}
                   </div>
                 </v-card-text>
               </v-card>
@@ -169,6 +178,9 @@
                     v{{ cliTotals.last_known_cli_version.cli_version }}
                   </v-chip>
                 </v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Source: Copilot Metrics API (<code>totals_by_cli</code>) · {{ rangeLabel }}
+                </v-card-subtitle>
                 <v-card-text>
                   <v-row dense>
                     <v-col cols="6" md="3">
@@ -277,6 +289,9 @@
             <v-col v-if="topIde" cols="12" :md="chartColumns === '2' ? 6 : 12">
               <v-card variant="outlined" class="h-100">
                 <v-card-title class="text-subtitle-1">Top IDE</v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Metrics API · {{ rangeLabel }}
+                </v-card-subtitle>
                 <v-card-text>
                   <strong>{{ topIde.ide }}</strong> —
                   {{ topIde.user_initiated_interaction_count.toLocaleString() }} interactions
@@ -295,6 +310,9 @@
             <v-col v-if="topModel" cols="12" :md="chartColumns === '2' ? 6 : 12">
               <v-card variant="outlined" class="h-100">
                 <v-card-title class="text-subtitle-1">Top model</v-card-title>
+                <v-card-subtitle class="text-caption text-medium-emphasis pb-2">
+                  Metrics API · {{ rangeLabel }}
+                </v-card-subtitle>
                 <v-card-text>
                   <strong>{{ topModel.model }}</strong> ({{ topModel.feature }}) —
                   {{ topModel.user_initiated_interaction_count.toLocaleString() }} interactions
@@ -320,8 +338,7 @@
                     <Bar :data="aiCreditsChartData" :options="aiCreditsChartOptions" />
                   </div>
                   <div class="text-caption text-medium-emphasis mt-1">
-                    Source: <code>ai_credits_used</code> on the users-1-day report
-                    (populated by GitHub since 2026-06-19).
+                    Source: Copilot Metrics API (<code>ai_credits_used</code> on the users-1-day report) · {{ rangeLabel }}
                   </div>
                 </v-card-text>
               </v-card>
@@ -350,7 +367,7 @@
                     <Bar :data="dailySpendChartData" :options="dailySpendChartOptions" />
                   </div>
                   <div class="text-caption text-medium-emphasis mt-1">
-                    Derived as <code>ai_credits_used × price-per-credit</code>. Price taken from your
+                    Derived from Metrics API <code>ai_credits_used</code> × price-per-credit · {{ rangeLabel }}. Price taken from your
                     billing spend response when available, otherwise the GitHub list price ($0.01/credit).
                   </div>
                 </v-card-text>
@@ -373,7 +390,7 @@
                     <Bar :data="dailyTokensChartData" :options="dailyTokensChartOptions" />
                   </div>
                   <div class="text-caption text-medium-emphasis mt-1">
-                    Source: <code>totals_by_cli.token_usage</code> on the users-1-day report.
+                    Source: Copilot Metrics API (<code>totals_by_cli.token_usage</code> on the users-1-day report) · {{ rangeLabel }}.
                     Only CLI tokens are exposed per-day today — IDE token usage is not broken down by day.
                   </div>
                 </v-card-text>
@@ -470,6 +487,19 @@ export default defineComponent({
       if (tp.month) parts.push(String(tp.month).padStart(2, '0'));
       if (tp.day) parts.push(String(tp.day).padStart(2, '0'));
       return parts.length ? parts.join('-') : 'Current billing period';
+    });
+
+    // Human label for the Metrics API window used by the tiles/CLI card/etc.
+    // Prefer the parent-provided `dateRangeDescription` (e.g. "Over the last
+    // 28 days" or a specific picker range). Otherwise fall back to the actual
+    // reportStartDay → reportEndDay returned by /api/my-usage. Only if both
+    // are missing do we say "last 28 days" as a last resort.
+    const rangeLabel = computed(() => {
+      if (props.dateRangeDescription) return props.dateRangeDescription;
+      const start = data.value?.reportStartDay;
+      const end = data.value?.reportEndDay;
+      if (start && end) return `${start} → ${end}`;
+      return 'last 28 days';
     });
 
     // True when the plan actually discounts spend (gross > net). Standalone
@@ -666,6 +696,7 @@ export default defineComponent({
 
     return {
       data, pending, error, initials, topIde, topModel, cliTotals, spendPeriodLabel,
+      rangeLabel,
       hasDiscount,
       aiCreditsChartData, aiCreditsChartOptions, aiCreditsTotalLabel, aiCreditsDayCount,
       dailySpendChartData, dailySpendChartOptions, dailySpendTotalLabel,

--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -505,7 +505,7 @@ export default defineComponent({
     // from the local billing_credit_usage table for a custom range.
     const spendCardTitle = computed(() =>
       data.value?.spend?.source === 'db'
-        ? 'AI credit spend (selected range)'
+        ? 'Your AI credit spend (selected range)'
         : 'Your AI credit spend (month-to-date)'
     );
     const spendSourceCaption = computed(() =>

--- a/e2e-tests/billing.spec.ts
+++ b/e2e-tests/billing.spec.ts
@@ -68,13 +68,38 @@ test.describe('Billing tab', () => {
         await expect(dashboard.page.getByRole('columnheader', { name: 'Product' })).toBeVisible();
     });
 
-    test('date-range bar is visible on the billing tab (drives DB-backed ranges when Month view is unchecked)', tag, async () => {
+    test('Month view toggle is checked by default and shows the month picker', tag, async () => {
+        const billing = await dashboard.gotoBillingTab();
+        await expect(billing.monthViewToggle).toBeVisible();
+        await expect(billing.monthViewToggle).toBeChecked();
+        // Month picker + prev/next buttons are only rendered when Month view is on.
+        await expect(billing.monthPicker).toBeVisible();
+        await expect(billing.rangeCaption).toBeHidden();
+    });
+
+    test('unchecking Month view hides the month picker and shows the dashboard-range caption', tag, async () => {
+        const billing = await dashboard.gotoBillingTab();
+        // Start from the default (checked); uncheck to switch to range mode.
+        await billing.monthViewToggle.uncheck();
+        await expect(billing.monthViewToggle).not.toBeChecked();
+        await expect(billing.monthPicker).toBeHidden();
+        await expect(billing.rangeCaption).toBeVisible();
+        // Re-checking restores the month picker.
+        await billing.monthViewToggle.check();
+        await expect(billing.monthPicker).toBeVisible();
+        await expect(billing.rangeCaption).toBeHidden();
+    });
+
+    test('global date-range selector is visible on the Billing tab (so range mode is usable)', tag, async () => {
         await dashboard.gotoBillingTab();
-        // As of the Month-view toggle change, the global DateRangeSelector is
-        // shown on the Billing tab so admins can filter DB-backed billing data
-        // to an arbitrary range (uncheck Month view above the tab to enable).
-        const monthViewCheckbox = dashboard.page.getByLabel('Month view', { exact: true });
-        await expect(monthViewCheckbox).toBeVisible();
+        // Prior behavior hid the DateRangeSelector on this tab; with the Month
+        // view toggle, the tab now uses it when Month view is unchecked, so
+        // the selector must be present in the DOM and visible.
+        const rangeSelector = dashboard.page.locator('.date-range-selector, [data-testid="date-range-selector"]').first();
+        // Fallback: the selector renders a "Date range" label somewhere.
+        const hasSelector = (await rangeSelector.count()) > 0
+            || (await dashboard.page.getByText(/date range/i).first().count()) > 0;
+        expect(hasSelector).toBe(true);
     });
 
     test('billing tab renders per-user breakdown table and top spenders chart', tag, async () => {

--- a/e2e-tests/billing.spec.ts
+++ b/e2e-tests/billing.spec.ts
@@ -68,23 +68,13 @@ test.describe('Billing tab', () => {
         await expect(dashboard.page.getByRole('columnheader', { name: 'Product' })).toBeVisible();
     });
 
-    test('date-range bar is hidden on the billing tab', tag, async () => {
+    test('date-range bar is visible on the billing tab (drives DB-backed ranges when Month view is unchecked)', tag, async () => {
         await dashboard.gotoBillingTab();
-        // The DateRangeBar is rendered with a `.date-range-bar` class and is
-        // gated v-show on `tab !== 'billing'` in MainComponent.vue.
-        const bar = dashboard.page.locator('.v-locale-provider').filter({
-            hasText: 'date range'
-        });
-        // The bar may not even be in the DOM; the more reliable check is the
-        // absence of its visible "Date range" / since-until inputs. Use a
-        // not-visible assertion on the calendar icon.
-        const calendarBtns = dashboard.page.getByRole('button', { name: /calendar/i });
-        // Either no calendar buttons, or none are visible.
-        if (await calendarBtns.count() > 0) {
-            await expect(calendarBtns.first()).toBeHidden();
-        }
-        // Silence the unused locator warning — assert nothing on `bar` directly.
-        expect(bar).toBeTruthy();
+        // As of the Month-view toggle change, the global DateRangeSelector is
+        // shown on the Billing tab so admins can filter DB-backed billing data
+        // to an arbitrary range (uncheck Month view above the tab to enable).
+        const monthViewCheckbox = dashboard.page.getByLabel('Month view', { exact: true });
+        await expect(monthViewCheckbox).toBeVisible();
     });
 
     test('billing tab renders per-user breakdown table and top spenders chart', tag, async () => {

--- a/e2e-tests/pages/BillingTab.ts
+++ b/e2e-tests/pages/BillingTab.ts
@@ -12,6 +12,9 @@ export class BillingTab {
     readonly netCostLabel: Locator;
     readonly dataTable: Locator;
     readonly heading: Locator;
+    readonly monthViewToggle: Locator;
+    readonly monthPicker: Locator;
+    readonly rangeCaption: Locator;
 
     constructor(page: Page) {
         this.page = page;
@@ -20,6 +23,11 @@ export class BillingTab {
         this.netCostLabel = page.getByText("Net cost (USD)", { exact: true });
         this.dataTable = page.locator(".v-data-table").first();
         this.heading = page.getByText("AI Credit Billing");
+        // v-checkbox renders an <input type=checkbox> inside a wrapper carrying
+        // data-testid. Reach the input so .check()/.uncheck()/.isChecked() work.
+        this.monthViewToggle = page.getByTestId("billing-month-view-toggle").locator("input[type=checkbox]");
+        this.monthPicker = page.getByTestId("billing-month-picker");
+        this.rangeCaption = page.getByTestId("billing-range-caption");
     }
 
     async expectVisible() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-metrics-viewer",
-      "version": "3.11.3",
+      "version": "3.11.4",
       "hasInstallScript": true,
       "dependencies": {
         "@azure/msal-browser": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-metrics-viewer",
-  "version": "3.11.3",
+  "version": "3.11.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/api/billing-credits-by-user.get.ts
+++ b/server/api/billing-credits-by-user.get.ts
@@ -91,10 +91,13 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
 
   if (dbEnterprise) {
     try {
+      const hasCustomRange = !!(query.since || query.until);
       const window = resolveWindow({
         year: query.year ? Number(query.year) : undefined,
         month: query.month ? Number(query.month) : undefined,
         day: query.day ? Number(query.day) : undefined,
+        since: query.since ? String(query.since) : undefined,
+        until: query.until ? String(query.until) : undefined,
       });
       const decision = await decideSource(dbEnterprise, window.startDate, window.endDate);
       if (decision.source === 'db') {
@@ -110,14 +113,37 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
       }
       setResponseHeader(event, 'X-Data-Source', 'live');
       setResponseHeader(event, 'X-Data-Source-Reason', decision.reason);
+      // Live GitHub API can't serve custom ranges — same 409 as /api/billing-credits.
+      if (hasCustomRange) {
+        throw createError({
+          statusCode: 409,
+          statusMessage:
+            `No ingested billing data covers ${window.startDate} → ${window.endDate}. ` +
+            `Enable Month view above or run the Billing CSV ingest in the Admin Panel.`,
+          data: { reason: 'range-requires-db', window },
+        });
+      }
     } catch (e) {
-      if (e instanceof Error && /Invalid|day without month/i.test(e.message)) {
+      const httpErr = e as { statusCode?: number };
+      if (httpErr && typeof httpErr.statusCode === 'number') throw e;
+      if (e instanceof Error && /Invalid|day without month|must be|since/i.test(e.message)) {
         throw createError({ statusCode: 400, statusMessage: e.message });
       }
       setResponseHeader(event, 'X-Data-Source', 'live');
       setResponseHeader(event, 'X-Data-Source-Reason',
         `db read failed: ${e instanceof Error ? e.message : String(e)}`);
     }
+  }
+
+  // Custom date ranges without a DB target (plain org scope) — same 409.
+  if ((query.since || query.until) && !dbEnterprise) {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        `Custom date ranges are served from the local database (enterprise-scoped only). ` +
+        `Set NUXT_BILLING_ENTERPRISE or enable Month view.`,
+      data: { reason: 'range-requires-db' },
+    });
   }
 
   // No fallback to NUXT_GITHUB_TOKEN: GitHub rejects fine-grained PATs and

--- a/server/api/billing-credits.get.ts
+++ b/server/api/billing-credits.get.ts
@@ -114,10 +114,13 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
 
   if (dbEnterprise) {
     try {
+      const hasCustomRange = !!(query.since || query.until);
       const window = resolveWindow({
         year: query.year ? Number(query.year) : undefined,
         month: query.month ? Number(query.month) : undefined,
         day: query.day ? Number(query.day) : undefined,
+        since: query.since ? String(query.since) : undefined,
+        until: query.until ? String(query.until) : undefined,
       });
       const decision = await decideSource(dbEnterprise, window.startDate, window.endDate);
       if (decision.source === 'db') {
@@ -138,9 +141,30 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
       // Record why so curl users can see in the response headers.
       setResponseHeader(event, 'X-Data-Source', 'live');
       setResponseHeader(event, 'X-Data-Source-Reason', decision.reason);
+
+      // Custom date ranges (since/until) can't be served by the live GitHub
+      // API — it only supports single-day or whole-month lookups. Rather
+      // than silently return the wrong window, fail loudly so the client
+      // can surface the "enable Month view or run Billing CSV ingest" banner.
+      if (hasCustomRange) {
+        throw createError({
+          statusCode: 409,
+          statusMessage:
+            `No ingested billing data covers ${window.startDate} → ${window.endDate}. ` +
+            `The GitHub Billing API only accepts a single day or a whole calendar month, ` +
+            `so custom ranges must be served from the local database. ` +
+            `Enable Month view above to look at a specific calendar month, or run the ` +
+            `Billing CSV ingest in the Admin Panel to import billing data for this range.`,
+          data: { reason: 'range-requires-db', window },
+        });
+      }
     } catch (e) {
+      // Preserve typed HTTP errors thrown above (e.g. the 409 for uncovered
+      // ranges) — only convert bare Error/validation failures to 400.
+      const httpErr = e as { statusCode?: number };
+      if (httpErr && typeof httpErr.statusCode === 'number') throw e;
       // Resolve-window 400s shouldn't be swallowed — re-throw as a clean 400.
-      if (e instanceof Error && /Invalid|day without month/i.test(e.message)) {
+      if (e instanceof Error && /Invalid|day without month|must be|since/i.test(e.message)) {
         throw createError({ statusCode: 400, statusMessage: e.message });
       }
       // Any other DB-side error: fall through to the live path, but flag it
@@ -149,6 +173,21 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
       setResponseHeader(event, 'X-Data-Source-Reason',
         `db read failed: ${e instanceof Error ? e.message : String(e)}`);
     }
+  }
+
+  // Custom date ranges require the DB path. If we couldn't resolve an
+  // enterprise for DB (e.g. plain org-scoped call without NUXT_BILLING_ENTERPRISE),
+  // reject with the same 409 rather than silently ignoring the range.
+  if ((query.since || query.until) && !dbEnterprise) {
+    throw createError({
+      statusCode: 409,
+      statusMessage:
+        `Custom date ranges on the Billing tab are served from the local database, ` +
+        `which is only populated for enterprise-scoped dashboards. ` +
+        `Set NUXT_BILLING_ENTERPRISE=<enterprise-slug> on the deployment, or ` +
+        `enable Month view above to look at a specific calendar month.`,
+      data: { reason: 'range-requires-db' },
+    });
   }
 
   // ── Token selection ────────────────────────────────────────────────────────

--- a/server/api/my-usage.get.ts
+++ b/server/api/my-usage.get.ts
@@ -33,6 +33,11 @@ import {
 } from '../services/github-copilot-usage-api';
 import { getUserDayMetricsByDateRange } from '../storage/user-day-metrics-storage';
 import { isDbConfigured } from '../storage/db';
+import {
+  aggregateForBilling,
+  decideSource,
+  resolveWindow,
+} from '../services/billing-credit-reader';
 import { buildBillingApiUrl } from '../utils/billing-url';
 import { aggregateBillingSpend, type BillingUsageItem } from '../utils/billing-spend-aggregator';
 import { isUsageAdminForEvent } from '../utils/usage-admin';
@@ -65,6 +70,15 @@ export interface MyUsageSpend {
   timePeriod?: { year?: number; month?: number; day?: number };
   /** Enterprise slug the billing call queried (echoed for the UI footnote). */
   enterprise?: string;
+  /**
+   * When the response was served from the local billing_credit_usage table
+   * (custom since/until range), these fields describe the actual window.
+   * When absent, the response came from the live GitHub Billing API and
+   * `timePeriod` describes the window instead.
+   */
+  source?: 'live' | 'db';
+  since?: string;
+  until?: string;
 }
 
 interface MyUsageResponse {
@@ -185,19 +199,36 @@ export default defineEventHandler(async (event): Promise<MyUsageResponse> => {
     // exercisable in mock mode / Playwright (no live billing endpoint needed).
     // Values are anonymized — derived from realistic SKU/model mixes scaled
     // down for the fixture user.
-    const mockSpend: MyUsageSpend = {
-      totalAmount: 18.42,
-      totalQuantity: 1842.0,
-      totalGrossAmount: 20.46,
-      totalGrossQuantity: 2046.0,
-      timePeriod: { year: 2026, month: 6 },
-      enterprise: 'mocked-enterprise',
-      byModel: [
-        { model: 'claude-sonnet-4.5', amount: 9.87, quantity: 987.0, grossAmount: 10.97, grossQuantity: 1097.0 },
-        { model: 'gpt-5.3-codex',     amount: 5.41, quantity: 541.0, grossAmount: 6.01,  grossQuantity: 601.0 },
-        { model: 'claude-haiku-4.5',  amount: 3.14, quantity: 314.0, grossAmount: 3.48,  grossQuantity: 348.0 },
-      ],
-    };
+    const mockSpend: MyUsageSpend = (options.since || options.until)
+      ? {
+          totalAmount: 9.11,
+          totalQuantity: 911.0,
+          totalGrossAmount: 10.12,
+          totalGrossQuantity: 1012.0,
+          enterprise: 'mocked-enterprise',
+          source: 'db',
+          since: options.since,
+          until: options.until,
+          byModel: [
+            { model: 'claude-sonnet-4.5', amount: 4.88, quantity: 488.0, grossAmount: 5.42, grossQuantity: 542.0 },
+            { model: 'gpt-5.3-codex',     amount: 2.67, quantity: 267.0, grossAmount: 2.97, grossQuantity: 297.0 },
+            { model: 'claude-haiku-4.5',  amount: 1.56, quantity: 156.0, grossAmount: 1.73, grossQuantity: 173.0 },
+          ],
+        }
+      : {
+          totalAmount: 18.42,
+          totalQuantity: 1842.0,
+          totalGrossAmount: 20.46,
+          totalGrossQuantity: 2046.0,
+          timePeriod: { year: 2026, month: 6 },
+          enterprise: 'mocked-enterprise',
+          source: 'live',
+          byModel: [
+            { model: 'claude-sonnet-4.5', amount: 9.87, quantity: 987.0, grossAmount: 10.97, grossQuantity: 1097.0 },
+            { model: 'gpt-5.3-codex',     amount: 5.41, quantity: 541.0, grossAmount: 6.01,  grossQuantity: 601.0 },
+            { model: 'claude-haiku-4.5',  amount: 3.14, quantity: 314.0, grossAmount: 3.48,  grossQuantity: 348.0 },
+          ],
+        };
 
     return { ...responseShell, totals, dayRecords, spend: mockSpend };
   }
@@ -310,9 +341,56 @@ async function fetchSelfSpend(
 ): Promise<{ data: MyUsageSpend } | { warning: string } | null> {
   const config = useRuntimeConfig(event);
   const billingToken = ((config.githubBillingToken as string | undefined) || '').trim();
-  if (!billingToken) return null;
-
   const billingEnterprise = ((config.billingEnterprise as string | undefined) || '').trim();
+
+  // ── DB-first path when a custom date range is set ────────────────────────
+  // The live billing API only supports single day / whole month / whole year
+  // windows, so arbitrary since/until ranges must come from ingested rows in
+  // billing_credit_usage. Same DB gate as /api/billing-credits: enterprise
+  // scope OR org scope with NUXT_BILLING_ENTERPRISE override.
+  const hasCustomRange = !!(options.since || options.until);
+  if (hasCustomRange) {
+    const dbEnterprise = billingEnterprise
+      || (options.scope === 'enterprise' ? (options.githubEnt || '') : '')
+      || '';
+    if (dbEnterprise && isDbConfigured()) {
+      try {
+        const window = resolveWindow({
+          since: options.since,
+          until: options.until,
+        });
+        const decision = await decideSource(dbEnterprise, window.startDate, window.endDate);
+        if (decision.source === 'db') {
+          const agg = await aggregateForBilling(dbEnterprise, window, { user: myLogin });
+          const spend = aggregateBillingSpend(agg.usageItems);
+          return {
+            data: {
+              ...spend,
+              enterprise: dbEnterprise,
+              source: 'db',
+              since: window.startDate,
+              until: window.endDate,
+            },
+          };
+        }
+        // DB doesn't cover the range and live API can't serve a custom range.
+        return {
+          warning:
+            `No ingested billing data covers ${window.startDate} → ${window.endDate}. ` +
+            `Run the Billing CSV ingest in the Admin Panel to import data for this range.`,
+        };
+      } catch (e) {
+        const msg = (e as { message?: string })?.message || String(e);
+        return { warning: `DB spend lookup failed: ${msg}` };
+      }
+    }
+    // No enterprise → can't serve custom range from anywhere; skip silently
+    // rather than falling back to a misleading month-to-date live call.
+    return null;
+  }
+
+  // ── Live current-month path ──────────────────────────────────────────────
+  if (!billingToken) return null;
   const baseUrl = (config.githubApiBaseUrl as string | undefined) || 'https://api.github.com';
 
   let url: string;
@@ -349,6 +427,7 @@ async function fetchSelfSpend(
         byModel,
         timePeriod: resp.timePeriod,
         enterprise: resp.enterprise || billingEnterprise || undefined,
+        source: 'live',
       },
     };
   } catch (error: unknown) {

--- a/server/services/billing-credit-reader.ts
+++ b/server/services/billing-credit-reader.ts
@@ -66,17 +66,45 @@ export interface AggregateFilters {
 }
 
 /**
- * Resolve `?year=&month=&day=` query params into an inclusive date window.
- * Mirrors how GitHub's billing endpoint interprets partial specifications:
- *   - year+month+day → that one day
- *   - year+month     → entire calendar month
- *   - year           → entire calendar year
- *   - none           → current calendar month (server "today" in UTC)
+ * Resolve `?year=&month=&day=` OR `?since=&until=` query params into an
+ * inclusive date window. Mirrors how GitHub's billing endpoint interprets
+ * partial specifications:
+ *   - since+until      → arbitrary range (DB-only; live API can't serve it)
+ *   - year+month+day   → that one day
+ *   - year+month       → entire calendar month
+ *   - year             → entire calendar year
+ *   - none             → current calendar month (server "today" in UTC)
  *
- * Throws on invalid input (out-of-range month/day) so the handler surfaces
- * a clean 400 instead of producing an empty/wrong window.
+ * `since/until` takes priority over year/month/day when both are supplied.
+ * When since/until is used, `timePeriod` is returned empty so the client
+ * knows the window is a custom range (not one of GitHub's standard buckets).
+ *
+ * Throws on invalid input (out-of-range month/day, malformed ISO dates,
+ * since > until) so the handler surfaces a clean 400.
  */
-export function resolveWindow(input: { year?: number; month?: number; day?: number }): BillingWindow {
+export function resolveWindow(input: {
+  year?: number;
+  month?: number;
+  day?: number;
+  since?: string;
+  until?: string;
+}): BillingWindow {
+  // Custom range takes precedence — used by the Billing tab's global
+  // date-range picker (Month view unchecked). DB path only.
+  if (input.since || input.until) {
+    if (!input.since || !input.until) {
+      throw new Error('Both `since` and `until` must be provided together');
+    }
+    const iso = /^\d{4}-\d{2}-\d{2}$/;
+    if (!iso.test(input.since) || !iso.test(input.until)) {
+      throw new Error('Invalid since/until — must be YYYY-MM-DD');
+    }
+    if (input.since > input.until) {
+      throw new Error(`since (${input.since}) must be <= until (${input.until})`);
+    }
+    return { startDate: input.since, endDate: input.until, timePeriod: {} };
+  }
+
   const now = new Date();
   const y = input.year ?? now.getUTCFullYear();
   const m = input.month ?? (input.year ? undefined : now.getUTCMonth() + 1);

--- a/tests/billing-credit-reader.spec.ts
+++ b/tests/billing-credit-reader.spec.ts
@@ -83,6 +83,38 @@ describe('resolveWindow', () => {
   it('rejects day without month', () => {
     expect(() => resolveWindow({ year: 2026, day: 5 })).toThrow(/day without month/i);
   });
+
+  it('accepts since+until as a custom range with empty timePeriod', () => {
+    const w = resolveWindow({ since: '2026-06-01', until: '2026-06-30' });
+    expect(w.startDate).toBe('2026-06-01');
+    expect(w.endDate).toBe('2026-06-30');
+    expect(w.timePeriod).toEqual({});
+  });
+
+  it('range mode takes precedence over year/month/day', () => {
+    const w = resolveWindow({
+      year: 2020, month: 1, day: 1,
+      since: '2026-06-15', until: '2026-06-20',
+    });
+    expect(w.startDate).toBe('2026-06-15');
+    expect(w.endDate).toBe('2026-06-20');
+    expect(w.timePeriod).toEqual({});
+  });
+
+  it('rejects since without until (and vice versa)', () => {
+    expect(() => resolveWindow({ since: '2026-06-01' })).toThrow(/both.*since.*until/i);
+    expect(() => resolveWindow({ until: '2026-06-30' })).toThrow(/both.*since.*until/i);
+  });
+
+  it('rejects malformed ISO dates in since/until', () => {
+    expect(() => resolveWindow({ since: '2026/06/01', until: '2026-06-30' })).toThrow(/YYYY-MM-DD/i);
+    expect(() => resolveWindow({ since: '2026-06-01', until: '06-30-2026' })).toThrow(/YYYY-MM-DD/i);
+  });
+
+  it('rejects since > until', () => {
+    expect(() => resolveWindow({ since: '2026-07-01', until: '2026-06-01' }))
+      .toThrow(/since.*<=.*until/i);
+  });
 });
 
 describe('decideSource', () => {

--- a/tests/billing-credits.db-first.spec.ts
+++ b/tests/billing-credits.db-first.spec.ts
@@ -57,7 +57,10 @@ vi.mock('../server/services/billing-credit-reader', () => ({
   decideSource: (...a: any[]) => mockDecide(...a),
   aggregateForBilling: (...a: any[]) => mockAggregate(...a),
   aggregateForBillingByUser: (...a: any[]) => mockAggregateByUser(...a),
-  resolveWindow: (input: { year?: number; month?: number; day?: number }) => {
+  resolveWindow: (input: { year?: number; month?: number; day?: number; since?: string; until?: string }) => {
+    if (input.since && input.until) {
+      return { startDate: input.since, endDate: input.until, timePeriod: {} };
+    }
     const y = input.year ?? 2026;
     const m = input.month ?? 6;
     return {
@@ -154,6 +157,63 @@ describe('GET /api/billing-credits — DB-first branch', () => {
     await billingHandler({} as any);
 
     expect(mockDecide).not.toHaveBeenCalled();
+  });
+
+  it('returns 409 range-requires-db when a since/until range is not covered by any ingest job', async () => {
+    setQuery({
+      scope: 'enterprise', githubEnt: 'ent-x',
+      since: '2026-05-01', until: '2026-06-15',
+    });
+    mockDecide.mockResolvedValueOnce({
+      source: 'live', reason: 'no completed ingest job covers window',
+      lastIngestAt: null, jobId: null,
+    });
+
+    let caught: any = null;
+    try { await billingHandler({} as any); } catch (e) { caught = e; }
+
+    expect(caught).toBeTruthy();
+    expect(caught.statusCode).toBe(409);
+    expect(caught.data?.reason).toBe('range-requires-db');
+    expect(caught.message).toMatch(/2026-05-01.*2026-06-15/);
+    // Live GitHub API MUST NOT be attempted for custom ranges.
+    expect(((globalThis as any).$fetch as any).mock.calls).toHaveLength(0);
+  });
+
+  it('serves a since/until range from DB when covered', async () => {
+    setQuery({
+      scope: 'enterprise', githubEnt: 'ent-x',
+      since: '2026-05-01', until: '2026-06-15',
+    });
+    mockDecide.mockResolvedValueOnce({
+      source: 'db', reason: 'covered by job #11', lastIngestAt: null, jobId: 11,
+    });
+    mockAggregate.mockResolvedValueOnce({
+      timePeriod: {}, enterprise: 'ent-x', usageItems: [],
+    });
+
+    await billingHandler({} as any);
+
+    expect(mockDecide).toHaveBeenCalledWith('ent-x', '2026-05-01', '2026-06-15');
+    expect(mockAggregate).toHaveBeenCalled();
+    expect(getHeader('X-Data-Source')).toBe('db');
+  });
+
+  it('rejects since/until on org-scoped calls with 409 range-requires-db', async () => {
+    setConfig({ billingEnterprise: '', githubBillingToken: 'tok' });
+    setQuery({
+      scope: 'organization', githubOrg: 'org-y',
+      since: '2026-05-01', until: '2026-06-15',
+    });
+
+    let caught: any = null;
+    try { await billingHandler({} as any); } catch (e) { caught = e; }
+
+    expect(caught).toBeTruthy();
+    expect(caught.statusCode).toBe(409);
+    expect(caught.data?.reason).toBe('range-requires-db');
+    expect(mockDecide).not.toHaveBeenCalled();
+    expect(((globalThis as any).$fetch as any).mock.calls).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
## Why

The **Billing** and **My Usage** tabs mix data from two sources with different windows (Billing API vs Metrics API), and until now this was invisible in the UI — easy to misread a per-user row where `$` came from one window and `tokens` from another. Also, the Billing tab ignored the dashboard-wide date-range picker entirely, so admins had no way to look at historical/per-day billing data even after ingesting billing CSVs into the DB.

## What

Two changes on one branch:

### 1. Label every section with its source + range
Every card, chart, and table on both tabs now carries a `Source · Range` subtitle that reactively updates when the date range changes (mirrors the "From 6/23/2026 to 7/8/2026 (16 days)" wording at the top of the tab). Existing hints (`Two credit numbers, two sources` alert, AI-credits tile tooltip) preserved and extended.

Concretely:
- **Billing tab**: total tiles / top spenders / top token users / per-user breakdown / raw billing line items — each subtitled with the source and window (Billing API + selected month vs. Metrics API + rolling 28 days).
- **My Usage tab**: 4 top tiles / CLI usage / Top IDE / Top model / all 3 daily charts — each subtitled with source and the actual selected date range.

### 2. Add a "Month view" toggle so the date-range picker can drive Billing
A checkbox on the Billing tab (default: checked) decides which control drives the fetch:

| Month view | Picker used | Fetch source |
|---|---|---|
| ✅ ON (default, unchanged behavior) | month picker on the tab | live GitHub Billing API (year+month or year+month+day) |
| ❌ OFF | dashboard-wide date-range picker | **DB only** (live API cannot serve arbitrary ranges) |

When Month view is OFF and no CSV ingest covers the range, the server returns a clean `409 range-requires-db` and the tab shows a red banner:
> *Either enable **Month view** to query the live GitHub Billing API for a specific month, or run the **Billing CSV ingest** in the Admin Panel to import data for &lt;selected range&gt;.*

The global `DateRangeSelector` is now visible on the Billing tab (previously hidden with `tab !== "billing"`).

## Server changes

- `server/services/billing-credit-reader.ts` — extended `resolveWindow()` to accept `since/until` as a custom range (empty `timePeriod`), with validation for ISO format + `since <= until`. Range mode takes precedence over year/month/day.
- `server/api/billing-credits.get.ts` and `.../by-user.get.ts` — both now:
  - forward `since/until` from the client
  - prefer the DB path via existing `decideSource()`
  - return `409 range-requires-db` (data: `{ reason: "range-requires-db", window }`) when live API cannot serve the range (both DB-coverage miss and plain-org scope without `NUXT_BILLING_ENTERPRISE`)
  - do NOT silently fall through to the live GitHub call for ranges — GitHub only supports single-day or whole-month lookups

## Client changes

- `app/components/MainComponent.vue` — Billing tab now receives `myUsageQueryParams` (which carries `since/until`) instead of `seatsQueryParams`; `DateRangeSelector` v-show gate updated.
- `app/components/BillingCreditsViewer.vue` — new `monthView` ref, tooltip explaining the tradeoff, conditional query builder (strips since/until in month mode, strips year/month/day in range mode), cache-invalidation on toggle, 409 banner, `rangeLabel` computed exposed to all captions.
- `app/components/MyUsageViewer.vue` — `rangeLabel` computed (prefers `dateRangeDescription` prop, falls back to `reportStartDay → reportEndDay`, then `"last 28 days"`); all captions I added use it so they reflect the actual picker range.

## Tests

- **Unit** (+9, total 744):
  - 6 new `resolveWindow` cases for since/until (accepts range, precedence over year/month/day, rejects one-sided, rejects malformed ISO, rejects `since > until`)
  - 3 new route-level cases in `billing-credits.db-first.spec.ts`: range served from DB, range with no coverage → 409, org scope + range → 409 (no live call attempted)
- **Playwright** (+3): Month view toggle visible + checked by default, uncheck hides month picker + shows range caption + re-check restores, global date-range selector visible on the Billing tab
- Added `data-testid` selectors: `billing-month-view-toggle`, `billing-month-picker`, `billing-range-caption` (repo convention per the "testing conventions" memory)

## Not covered

The 409 banner path has no e2e coverage because the `/api/billing-credits` handler short-circuits in mock mode; exercising the DB decision requires a real Postgres in Playwright (much bigger scope). Instead covered by unit tests that pin the handler wiring.

## Version bump

`package.json` → `3.11.4` (previous release was `3.11.3`).

## Screenshots

_(none — captions/subtitles + a checkbox; visual diff is trivial and safe to review from the code.)_

## Commits

1. `docs(ui)` — source+range captions on both tabs (with dynamic rangeLabel)
2. `feat(billing)` — Month view toggle + server since/until support + 409 banner
3. `test(billing)` — Playwright coverage + data-testid selectors

## Issue
Fixes #414 