### PR TITLE
fix(ui): correct Top token users empty-state guidance

### DIFF
--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -257,9 +257,14 @@
                   <div v-if="topTokensChartData" style="height: 280px">
                     <Bar :data="topTokensChartData" :options="topTokensChartOptions" />
                   </div>
-                  <v-alert v-else type="info" variant="tonal" density="compact">
-                    No per-user CLI token usage available — load the User Metrics tab
-                    once so token data is fetched, then revisit.
+                  <v-alert
+                    v-else
+                    type="info"
+                    variant="tonal"
+                    density="compact"
+                    data-testid="billing-top-token-users-empty-state"
+                  >
+                    No CLI token usage was reported for any user in this period.
                   </v-alert>
                 </v-card-text>
               </v-card>

--- a/tests/billing-credits-top-token-empty-state.spec.ts
+++ b/tests/billing-credits-top-token-empty-state.spec.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+import { describe, expect, test } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const componentSource = readFileSync(
+  new URL('../app/components/BillingCreditsViewer.vue', import.meta.url),
+  'utf8'
+);
+
+describe('BillingCreditsViewer Top token users empty state', () => {
+  test('uses accurate guidance when no CLI token usage is reported', () => {
+    expect(componentSource).toContain('data-testid="billing-top-token-users-empty-state"');
+    expect(componentSource).toContain('No CLI token usage was reported for any user in this period.');
+    expect(componentSource).not.toContain('load the User Metrics tab');
+  });
+});


### PR DESCRIPTION
Fixes #423

## Summary
- Replace the inaccurate cross-tab guidance with an accurate no-usage empty state.
- Add a stable data-testid for the Top token users empty state.
- Add a Vitest regression test for the copy and test id.

## Validation
- npm test -- tests/billing-credits-top-token-empty-state.spec.ts --run --reporter dot
- npm run build

Note: full npm test was also attempted, but this symlinked worktree currently fails before running affected tests because Nuxt test-utils resolves its runtime entry through /@fs/home/... under the shared node_modules symlink.