### PR TITLE
Fix Top spenders for fully-discounted billing plans

### DIFF
--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -396,6 +396,7 @@ import {
   Legend,
 } from 'chart.js';
 import { PALETTE } from '@/utils/chartPlugins';
+import { buildTopSpendersChartData } from '@/utils/billingTopSpenders';
 import type { BillingCreditsResponse, BillingUsageItem } from '../../server/api/billing-credits.get';
 import { buildDataSourceBadge } from '#shared/utils/data-source-badge';
 
@@ -719,23 +720,7 @@ export default defineComponent({
     ];
 
     const topSpendersChartData = computed(() => {
-      // Sort by netAmount desc and drop $0 rows so enterprises with no
-      // per-user attribution (or pages we haven't lazy-loaded yet) don't
-      // render a chart full of zero bars labelled "top spenders".
-      const withSpend = perUserRows.value.filter(r => r.netAmount > 0);
-      if (withSpend.length === 0) return null;
-      const top = [...withSpend].sort((a, b) => b.netAmount - a.netAmount).slice(0, 10);
-      return {
-        labels: top.map(r => r.user),
-        datasets: [
-          {
-            label: 'Net spend (USD)',
-            data: top.map(r => +r.netAmount.toFixed(2)),
-            backgroundColor: PALETTE?.[0]?.bg ?? '#3f51b5',
-            borderRadius: 4,
-          },
-        ],
-      };
+      return buildTopSpendersChartData(perUserRows.value, PALETTE?.[0]?.bg ?? '#3f51b5');
     });
 
     const topSpendersChartOptions = {

--- a/app/utils/billingTopSpenders.ts
+++ b/app/utils/billingTopSpenders.ts
@@ -1,0 +1,41 @@
+export interface BillingTopSpenderRow {
+  user: string;
+  grossAmount: number;
+  netAmount: number;
+}
+
+export function buildTopSpendersChartData(
+  rows: BillingTopSpenderRow[],
+  backgroundColor: string,
+) {
+  const maxNetAmount = rows.reduce((max, row) => {
+    const netAmount = Number.isFinite(row.netAmount) ? row.netAmount : 0;
+    return Math.max(max, netAmount);
+  }, 0);
+  const spendKey: 'netAmount' | 'grossAmount' = maxNetAmount > 0 ? 'netAmount' : 'grossAmount';
+  const label = spendKey === 'netAmount' ? 'Net spend (USD)' : 'Gross spend (USD)';
+  const withSpend = rows.filter((row) => {
+    const amount = Number.isFinite(row[spendKey]) ? row[spendKey] : 0;
+    return amount > 0;
+  });
+  if (withSpend.length === 0) return null;
+
+  const top = [...withSpend]
+    .sort((a, b) => {
+      const spendDiff = b[spendKey] - a[spendKey];
+      return spendDiff || b.grossAmount - a.grossAmount;
+    })
+    .slice(0, 10);
+
+  return {
+    labels: top.map(row => row.user),
+    datasets: [
+      {
+        label,
+        data: top.map(row => +row[spendKey].toFixed(2)),
+        backgroundColor,
+        borderRadius: 4,
+      },
+    ],
+  };
+}

--- a/tests/billing-top-spenders.spec.ts
+++ b/tests/billing-top-spenders.spec.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { buildTopSpendersChartData } from '../app/utils/billingTopSpenders';
+
+describe('buildTopSpendersChartData', () => {
+  it('falls back to gross spend when every loaded user has zero net spend', () => {
+    const result = buildTopSpendersChartData([
+      { user: 'alice', grossAmount: 25, netAmount: 0 },
+      { user: 'bob', grossAmount: 100, netAmount: 0 },
+    ], '#3f51b5');
+
+    expect(result).toMatchObject({
+      labels: ['bob', 'alice'],
+      datasets: [
+        {
+          label: 'Gross spend (USD)',
+          data: [100, 25],
+        },
+      ],
+    });
+  });
+
+  it('continues ranking by net spend when any loaded user has net spend', () => {
+    const result = buildTopSpendersChartData([
+      { user: 'alice', grossAmount: 100, netAmount: 5 },
+      { user: 'bob', grossAmount: 25, netAmount: 10 },
+    ], '#3f51b5');
+
+    expect(result).toMatchObject({
+      labels: ['bob', 'alice'],
+      datasets: [
+        {
+          label: 'Net spend (USD)',
+          data: [10, 5],
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Fixes #419

## Summary
- Rank Top spenders by net spend unless all loaded net spend is zero
- Fall back to gross spend for fully-discounted plans so the chart is not empty
- Add a regression test for all-zero net/non-zero gross billing rows

## Validation
- npm test -- --run --hookTimeout=30000 --reporter=json --outputFile=vitest-results.json --silent (746/746 passed)
- npm run build

Note: npm run lint -- --quiet currently fails before linting due an existing dependency export error in eslint-plugin-import-x/minimatch. npm audit reports existing dependency advisories on the default branch.