### PR TITLE
feat(my-usage): add accepted lines tooltip

### DIFF
--- a/app/components/MyUsageViewer.vue
+++ b/app/components/MyUsageViewer.vue
@@ -122,7 +122,23 @@
             <v-col cols="12" sm="6" md="3">
               <v-card variant="tonal" color="deep-purple" class="h-100">
                 <v-card-text>
-                  <div class="text-caption">Accepted lines</div>
+                  <div class="text-caption d-flex align-center">
+                    Accepted lines
+                    <v-tooltip location="top" max-width="280">
+                      <template #activator="{ props: tipProps }">
+                        <v-icon
+                          v-bind="tipProps"
+                          data-testid="my-usage-accepted-lines-tooltip"
+                          size="14"
+                          class="ml-1"
+                          color="deep-purple"
+                        >
+                          mdi-information-outline
+                        </v-icon>
+                      </template>
+                      <span>Lines added from accepted completions and agent edits. Chat / ask-only usage adds no lines, so this can be 0 even with many interactions.</span>
+                    </v-tooltip>
+                  </div>
                   <div class="text-h4 font-weight-bold">
                     {{ data.totals.loc_added_sum.toLocaleString() }}
                   </div>

--- a/tests/MyUsageViewer.source.spec.ts
+++ b/tests/MyUsageViewer.source.spec.ts
@@ -1,0 +1,16 @@
+// @vitest-environment node
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const componentSource = readFileSync(resolve(__dirname, '../app/components/MyUsageViewer.vue'), 'utf8');
+
+describe('MyUsageViewer source', () => {
+  it('documents why accepted lines can be zero for chat-only usage', () => {
+    expect(componentSource).toContain('data-testid="my-usage-accepted-lines-tooltip"');
+    expect(componentSource).toContain('Lines added from accepted completions and agent edits. Chat / ask-only usage adds no lines, so this can be 0 even with many interactions.');
+  });
+});


### PR DESCRIPTION
Fixes #433

## Summary
- Added an info tooltip to the My Usage Accepted lines tile explaining chat / ask-only usage can legitimately show 0 lines.
- Added a stable `data-testid` for the tooltip activator.
- Added a source-level Vitest regression test for the tooltip copy and test id.

## Validation
- PASS: `npm test -- tests/MyUsageViewer.source.spec.ts --run`
- PASS: `NUXT_BUILD_DIR=.nuxt npm run build`
- NOTE: plain `npm test -- --run` and plain `npm run build` hit existing symlinked-worktree Nuxt/Vitest path issues in this environment (`/@fs/...@nuxt/test-utils...` and missing Nuxt manifest).
- NOTE: `npm run lint` currently fails during ESLint startup due dependency resolution (`brace-expansion` export); `npm audit --audit-level=high --omit=dev` reports existing dependency advisories.