### PR TITLE
Structured leveled logging with request IDs

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -88,6 +88,9 @@ export default defineNuxtConfig({
     // GitHub App credentials (alternative to PAT — works with any OAuth provider)
     githubAppId: '',            // NUXT_GITHUB_APP_ID — numeric App ID (preferred); GitHub also accepts the Client ID (NUXT_OAUTH_GITHUB_CLIENT_ID)
     githubAppPrivateKey: '',    // NUXT_GITHUB_APP_PRIVATE_KEY (PEM, \n-escaped)
+    logLevel: process.env.NUXT_LOG_LEVEL || 'info',
+    logFormat: process.env.NUXT_LOG_FORMAT || '',
+    logRequests: process.env.NUXT_LOG_REQUESTS || 'false',
     session: {
       // set to 6h - same as the GitHub token
       maxAge: 60 * 60 * 6,

--- a/server/api/admin/overview.get.ts
+++ b/server/api/admin/overview.get.ts
@@ -16,6 +16,9 @@ import { getPool, isDbConfigured } from '../../storage/db';
 import { getFailedSyncsForScope, getPendingSyncsForScope } from '../../storage/sync-storage';
 import { getSyncStats } from '../../services/sync-service';
 import { isMockMode } from '../../services/github-copilot-usage-api-mock';
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('admin-overview')
 
 interface OverviewResponse {
   db: { connected: boolean; latencyMs?: number; error?: string };
@@ -159,7 +162,7 @@ export default defineEventHandler(async (event): Promise<OverviewResponse> => {
       lastAttemptAt: f.lastAttemptAt,
     }));
   } catch (err) {
-    console.warn('[admin/overview] Enrichment failed:', err);
+    logger.warn('Enrichment failed:', err);
   }
 
   return response;

--- a/server/api/ai/chat.post.ts
+++ b/server/api/ai/chat.post.ts
@@ -15,6 +15,9 @@ import { aiTools, buildSystemPrompt } from '../../services/ai-tools';
 import { executeTool, type ToolCallRequest } from '../../services/ai-tool-executor';
 import { isMockMode } from '../../services/github-copilot-usage-api-mock';
 import { generateMockChatResponse } from '../../services/ai-chat-mock';
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('ai-chat')
 
 interface ChatMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -166,7 +169,7 @@ export default defineEventHandler(async (event) => {
       lastResponse = await callGitHubModels(githubToken, model, messages, aiTools);
     } catch (error: unknown) {
       const message = error instanceof Error ? error.message : String(error);
-      console.error(`GitHub Models API error (round ${round}):`, message);
+      logger.error(`GitHub Models API error (round ${round}):`, error);
 
       if (message.includes('401') || message.includes('403') || message.includes('no_access')) {
         throw createError({

--- a/server/middleware/log.ts
+++ b/server/middleware/log.ts
@@ -1,3 +1,56 @@
+import { randomUUID } from 'node:crypto'
+import { createLogger, getRuntimeLoggingConfig, isLogLevelAtLeast } from '../utils/logger'
+
+const logger = createLogger('request')
+const HEALTH_PATHS = new Set(['/api/health', '/api/live', '/api/ready'])
+const STATIC_PREFIXES = ['/_nuxt/', '/assets/']
+const STATIC_FILE_PATTERN = /\.(?:css|js|mjs|map|ico|png|jpg|jpeg|gif|svg|webp|woff2?|ttf|eot)$/i
+
+function getPath(url?: string): string {
+  try {
+    return new URL(url || '/', 'http://localhost').pathname
+  } catch {
+    return '/'
+  }
+}
+
+function getRequestId(event: any): string {
+  const header = event.node.req.headers?.['x-request-id']
+  if (Array.isArray(header)) return header[0] || randomUUID()
+  return header || randomUUID()
+}
+
+function shouldSkipPath(path: string): boolean {
+  return HEALTH_PATHS.has(path)
+    || STATIC_PREFIXES.some(prefix => path.startsWith(prefix))
+    || STATIC_FILE_PATTERN.test(path)
+}
+
 export default defineEventHandler((event) => {
-  console.log('Request: ' + event.method + ' ' + getRequestURL(event))
+  const requestId = getRequestId(event)
+  event.context.requestId = requestId
+  event.node.res.setHeader('x-request-id', requestId)
+
+  const path = getPath(event.node.req.url)
+  if (shouldSkipPath(path)) return
+
+  const config = getRuntimeLoggingConfig()
+  const forceRequestLogs = config.logRequests === 'true'
+  if (!forceRequestLogs && !isLogLevelAtLeast(config.logLevel, 'debug')) return
+
+  const startedAt = Date.now()
+  event.node.res.on('finish', () => {
+    const payload = {
+      method: event.method || event.node.req.method,
+      path,
+      status: event.node.res.statusCode,
+      durationMs: Date.now() - startedAt,
+      requestId,
+    }
+    if (forceRequestLogs) {
+      logger.info('Request completed', payload)
+    } else {
+      logger.debug('Request completed', payload)
+    }
+  })
 })

--- a/server/modules/github-app-auth.ts
+++ b/server/modules/github-app-auth.ts
@@ -1,5 +1,6 @@
 import { createPrivateKey, createSign } from 'node:crypto'
 import type { H3Event, EventHandlerRequest } from 'h3'
+import { createLogger } from '../utils/logger'
 
 // ofetch fallback for standalone (non-Nitro) environments.
 // In Nitro the global `$fetch` is provided automatically, but this module is
@@ -11,6 +12,7 @@ const _fetch: typeof _ofetch = typeof $fetch !== 'undefined' ? ($fetch as typeof
 
 const TOKEN_EXPIRY_BUFFER_SECONDS = 300 // refresh 5 min before expiry
 const INSTALLATIONS_CACHE_TTL_SECONDS = 300 // re-list installations every 5 min
+const logger = createLogger('github-app-auth')
 
 export interface AppInstallation {
   id: number
@@ -59,7 +61,7 @@ function signJWT(payload: Record<string, unknown>, privateKeyPem: string): strin
 /** Build a short-lived JWT for GitHub App API calls. */
 function buildAppJwt(appId: string, privateKey: string): string {
   const now = Math.floor(Date.now() / 1000)
-  console.log('[github-app-auth] Building App JWT')
+  logger.debug('Building App JWT')
   try {
     return signJWT({ iss: appId, iat: now - 10, exp: now + 600 }, privateKey)
   } catch (err: unknown) {

--- a/server/plugins/auth-config-check.ts
+++ b/server/plugins/auth-config-check.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../utils/logger'
+
+const logger = createLogger('auth-config-check')
+
 /**
  * Startup self-check for auth misconfiguration that could silently disable
  * issue-#398 user-data restriction.
@@ -33,8 +37,8 @@ export default defineNitroPlugin(() => {
     || process.env.NUXT_OAUTH_GITHUB_CLIENT_SECRET)
 
   if (oauthLooksConfigured && !authConfigured) {
-    console.warn(
-      '[auth-config-check] OAuth credentials appear to be configured ' +
+    logger.warn(
+      'OAuth credentials appear to be configured ' +
       '(NUXT_OAUTH_GITHUB_CLIENT_ID/SECRET) but none of ' +
       'NUXT_PUBLIC_USING_GITHUB_AUTH / NUXT_PUBLIC_REQUIRE_AUTH / ' +
       'NUXT_PUBLIC_IS_PUBLIC_APP / NUXT_PUBLIC_AUTH_PROVIDERS is set. ' +

--- a/server/plugins/db-init.ts
+++ b/server/plugins/db-init.ts
@@ -4,6 +4,9 @@
  */
 
 import { isDbConfigured } from '../storage/db';
+import { createLogger } from '../utils/logger';
+
+const logger = createLogger('db-init');
 
 export default defineNitroPlugin(async () => {
   if (!isDbConfigured()) return;
@@ -14,9 +17,9 @@ export default defineNitroPlugin(async () => {
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      console.log(`Initializing PostgreSQL schema (attempt ${attempt}/${maxRetries})...`);
+      logger.info(`Initializing PostgreSQL schema (attempt ${attempt}/${maxRetries})...`);
       await initSchema();
-      console.log('PostgreSQL schema ready');
+      logger.info('PostgreSQL schema ready');
       return;
     } catch (error: unknown) {
       const pgCode = error && typeof error === 'object' && 'code' in error ? (error as { code: string }).code : '';
@@ -25,10 +28,10 @@ export default defineNitroPlugin(async () => {
 
       if ((isStartingUp || isConnRefused) && attempt < maxRetries) {
         const delay = baseDelay * attempt;
-        console.log(`PostgreSQL not ready yet, retrying in ${delay / 1000}s...`);
+        logger.warn(`PostgreSQL not ready yet, retrying in ${delay / 1000}s...`);
         await new Promise(resolve => setTimeout(resolve, delay));
       } else {
-        console.error('Failed to initialize PostgreSQL schema:', error);
+        logger.error('Failed to initialize PostgreSQL schema:', error);
         return;
       }
     }

--- a/server/routes/auth/auth0.get.ts
+++ b/server/routes/auth/auth0.get.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('auth-auth0')
+
 export default defineOAuthAuth0EventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.email || ''
@@ -18,7 +22,7 @@ export default defineOAuthAuth0EventHandler({
     return sendRedirect(event, defaultOrg ? getAppBaseURL(event) : appURL('/select-org', event))
   },
   onError(event, error) {
-    console.error('Auth0 OAuth error:', error)
+    logger.error('Auth0 OAuth error:', error)
     return sendRedirect(event, getAppBaseURL(event))
   }
 })

--- a/server/routes/auth/github.get.ts
+++ b/server/routes/auth/github.get.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('auth-github')
+
 export default defineOAuthGitHubEventHandler({
   config: {
     // Default scopes: read:user for profile, read:org for org membership (used by org picker).
@@ -63,7 +67,7 @@ export default defineOAuthGitHubEventHandler({
           return sendRedirect(event, appURL(`/orgs/${organizations[0]!.login}`, event))
         }
       } catch (err) {
-        console.error('Error fetching installations:', err)
+        logger.warn('Error fetching installations:', err)
         // Fall through to /select-org which shows a text input fallback.
       }
     }
@@ -72,7 +76,7 @@ export default defineOAuthGitHubEventHandler({
   },
   // Optional, will return a json error and 401 status code by default
   onError(event, error) {
-    console.error('GitHub OAuth error:', error)
+    logger.error('GitHub OAuth error:', error)
     return sendRedirect(event, getAppBaseURL(event))
   },
 })

--- a/server/routes/auth/google.get.ts
+++ b/server/routes/auth/google.get.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('auth-google')
+
 export default defineOAuthGoogleEventHandler({
   async onSuccess(event, { user }) {
     if (!isUserAuthorized(event, { email: user.email })) {
@@ -22,7 +26,7 @@ export default defineOAuthGoogleEventHandler({
     return sendRedirect(event, getAppBaseURL(event))
   },
   onError(event, error) {
-    console.error('Google OAuth error:', error)
+    logger.error('Google OAuth error:', error)
     return sendRedirect(event, getAppBaseURL(event))
   }
 })

--- a/server/routes/auth/keycloak.get.ts
+++ b/server/routes/auth/keycloak.get.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('auth-keycloak')
+
 export default defineOAuthKeycloakEventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.email || ''
@@ -18,7 +22,7 @@ export default defineOAuthKeycloakEventHandler({
     return sendRedirect(event, defaultOrg ? getAppBaseURL(event) : appURL('/select-org', event))
   },
   onError(event, error) {
-    console.error('Keycloak OAuth error:', error)
+    logger.error('Keycloak OAuth error:', error)
     return sendRedirect(event, getAppBaseURL(event))
   }
 })

--- a/server/routes/auth/microsoft.get.ts
+++ b/server/routes/auth/microsoft.get.ts
@@ -1,3 +1,7 @@
+import { createLogger } from '../../utils/logger'
+
+const logger = createLogger('auth-microsoft')
+
 export default defineOAuthMicrosoftEventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.mail || user.userPrincipalName || ''
@@ -18,7 +22,7 @@ export default defineOAuthMicrosoftEventHandler({
     return sendRedirect(event, defaultOrg ? getAppBaseURL(event) : appURL('/select-org', event))
   },
   onError(event, error) {
-    console.error('Microsoft OAuth error:', error)
+    logger.error('Microsoft OAuth error:', error)
     return sendRedirect(event, getAppBaseURL(event))
   }
 })

--- a/server/services/github-copilot-usage-api.ts
+++ b/server/services/github-copilot-usage-api.ts
@@ -5,6 +5,10 @@
  */
 
 import { isMockMode, mockRequestDownloadLinks, mockRequestUserDownloadLinks, generateMockReport } from './github-copilot-usage-api-mock';
+import { createLogger } from '../utils/logger'
+
+const newApiLogger = createLogger('new-api')
+const userMetricsLogger = createLogger('user-metrics-api')
 
 // Import $fetch for standalone (non-Nitro) environments
 // In Nitro context, $fetch is auto-imported; this is a no-op there
@@ -660,7 +664,7 @@ export async function requestDownloadLinks(
   } catch (error: unknown) {
     // Log the response body for better debugging
     if (error && typeof error === 'object' && 'data' in error) {
-      console.error('[new-api] GitHub error response:', JSON.stringify((error as { data: unknown }).data));
+      newApiLogger.error('GitHub error response:', { data: (error as { data: unknown }).data });
     }
     throw error;
   }
@@ -895,7 +899,7 @@ export async function requestUserDownloadLinks(
     return response;
   } catch (error: unknown) {
     if (error && typeof error === 'object' && 'data' in error) {
-      console.error('[user-metrics-api] GitHub error response:', JSON.stringify((error as { data: unknown }).data));
+      userMetricsLogger.error('GitHub error response:', { data: (error as { data: unknown }).data });
     }
     throw error;
   }
@@ -921,7 +925,7 @@ export async function downloadUserReport(downloadUrl: string): Promise<UserRepor
         records = parsed;
       } else if (parsed && typeof parsed === 'object' && Array.isArray(parsed.user_totals)) {
         // Already in UserReport shape (mock data format)
-        console.info('[user-metrics-api] Download is pre-aggregated UserReport');
+        userMetricsLogger.info('Download is pre-aggregated UserReport');
         return parsed as UserReport;
       } else {
         records = [parsed];
@@ -936,7 +940,7 @@ export async function downloadUserReport(downloadUrl: string): Promise<UserRepor
   } else if (raw && typeof raw === 'object' && 'user_totals' in (raw as Record<string, unknown>)) {
     return raw as UserReport;
   } else {
-    console.error('[user-metrics-api] Unexpected download response type:', typeof raw);
+    userMetricsLogger.error('Unexpected download response type:', { responseType: typeof raw });
     return { report_start_day: '', report_end_day: '', user_totals: [] };
   }
 
@@ -951,7 +955,7 @@ export async function downloadUserReport(downloadUrl: string): Promise<UserRepor
     // Also surface the raw per-day per-user rows as `day_totals` so callers
     // can render a day-by-day chart without making 28 follow-up 1-day calls.
     const dayRecords = records as UserDayRecord[];
-    console.info(`[user-metrics-api] Aggregating ${dayRecords.length} daily user records`);
+    userMetricsLogger.info(`Aggregating ${dayRecords.length} daily user records`);
     const userTotals = aggregateUserDayRecords(dayRecords);
     return {
       report_start_day: first.report_start_day as string || '',
@@ -965,11 +969,11 @@ export async function downloadUserReport(downloadUrl: string): Promise<UserRepor
 
   // Pre-aggregated format (mock data / already-aggregated) — array of UserTotals
   if ('login' in first) {
-    console.info(`[user-metrics-api] Download has ${records.length} pre-aggregated user records`);
+    userMetricsLogger.info(`Download has ${records.length} pre-aggregated user records`);
     return { report_start_day: '', report_end_day: '', user_totals: records as UserTotals[] };
   }
 
-  console.warn('[user-metrics-api] Unknown record format. Keys:', Object.keys(first));
+  userMetricsLogger.warn('Unknown record format. Keys:', { keys: Object.keys(first) });
   return { report_start_day: '', report_end_day: '', user_totals: [] };
 }
 

--- a/server/services/github-saml-service.ts
+++ b/server/services/github-saml-service.ts
@@ -4,6 +4,10 @@
  * Results are cached per-org for 1 hour to avoid repeated GraphQL calls.
  */
 
+import { createLogger } from '../utils/logger'
+
+const logger = createLogger('saml-service')
+
 interface SamlCache {
   map: Map<string, string>
   expiry: number
@@ -86,7 +90,7 @@ export async function fetchSamlIdentities(
       const json = await resp.json() as GraphQLResponse
 
       if (json.errors?.length) {
-        console.warn(`[saml-service] GraphQL errors for org "${org}":`, json.errors.map(e => e.message))
+        logger.warn(`GraphQL errors for org "${org}":`, { errors: json.errors.map(e => e.message) })
         break
       }
 
@@ -102,7 +106,7 @@ export async function fetchSamlIdentities(
       after = ext.pageInfo.hasNextPage ? ext.pageInfo.endCursor : null
     } while (after)
   } catch (err) {
-    console.warn(`[saml-service] Failed to fetch SAML identities for org "${org}":`, err)
+    logger.warn(`Failed to fetch SAML identities for org "${org}":`, err)
   }
 
   samlCache.set(cacheKey, { map: nameIdToLogin, expiry: Date.now() + TTL_MS })

--- a/server/services/sync-service.ts
+++ b/server/services/sync-service.ts
@@ -24,6 +24,9 @@ import {
   markSyncFailed,
   getSyncStatus
 } from '../storage/sync-storage';
+import { createLogger } from '../utils/logger'
+
+const logger = createLogger('sync-service')
 
 export interface SyncRequest {
   scope: 'organization' | 'enterprise';
@@ -378,11 +381,11 @@ export async function syncGaps(
   const missingDates = await detectGaps(scope, identifier, startDate, endDate, teamSlug);
   
   if (missingDates.length === 0) {
-    console.log('No gaps detected, all dates already synced');
+    logger.info('No gaps detected, all dates already synced');
     return { results: [], gapsDetected: 0, outsideWindow: 0 };
   }
 
-  console.log(`Found ${missingDates.length} missing dates, attempting to fill...`);
+  logger.info(`Found ${missingDates.length} missing dates, attempting to fill...`);
 
   // First try bulk 28-day download (efficient for recent gaps)
   const bulkRequest: MetricsReportRequest = { scope, identifier, teamSlug };
@@ -407,7 +410,7 @@ export async function syncGaps(
 
   // Fill out-of-window gaps using the 1-day endpoint (one call per date)
   if (outOfWindowDates.length > 0) {
-    console.log(`${outOfWindowDates.length} gap(s) outside 28-day window — fetching via 1-day endpoint...`);
+    logger.info(`${outOfWindowDates.length} gap(s) outside 28-day window — fetching via 1-day endpoint...`);
     for (const date of outOfWindowDates) {
       const dayResult = await syncMetricsForDate({ scope, identifier, date, teamSlug, headers });
       results.push(dayResult);

--- a/server/utils/logger.ts
+++ b/server/utils/logger.ts
@@ -1,0 +1,122 @@
+import { createConsola, LogLevels, type ConsolaReporter, type LogType } from 'consola'
+
+type SupportedLogLevel = 'silent' | 'error' | 'warn' | 'info' | 'debug'
+type LogMethod = (message: string, ...args: unknown[]) => void
+
+export interface TaggedLogger {
+  error: LogMethod
+  warn: LogMethod
+  info: LogMethod
+  debug: LogMethod
+}
+
+const DEFAULT_LEVEL: SupportedLogLevel = 'info'
+const LEVELS: Record<SupportedLogLevel, number> = {
+  silent: LogLevels.silent,
+  error: LogLevels.error,
+  warn: LogLevels.warn,
+  info: LogLevels.info,
+  debug: LogLevels.debug,
+}
+
+export function getRuntimeLoggingConfig(): { logLevel?: string; logFormat?: string; logRequests?: string } {
+  try {
+    const runtimeConfig = (globalThis as unknown as { useRuntimeConfig?: () => unknown }).useRuntimeConfig
+    if (typeof runtimeConfig === 'function') {
+      return runtimeConfig() as { logLevel?: string; logFormat?: string; logRequests?: string }
+    }
+    if (typeof useRuntimeConfig === 'function') {
+      return useRuntimeConfig() as { logLevel?: string; logFormat?: string; logRequests?: string }
+    }
+  } catch {
+    // useRuntimeConfig is unavailable in standalone scripts and some tests.
+  }
+  return {
+    logLevel: process.env.NUXT_LOG_LEVEL,
+    logFormat: process.env.NUXT_LOG_FORMAT,
+    logRequests: process.env.NUXT_LOG_REQUESTS,
+  }
+}
+
+export function normalizeLogLevel(level: unknown): SupportedLogLevel {
+  return typeof level === 'string' && level in LEVELS ? level as SupportedLogLevel : DEFAULT_LEVEL
+}
+
+export function isLogLevelAtLeast(level: unknown, minimum: SupportedLogLevel): boolean {
+  const normalized = normalizeLogLevel(level)
+  if (normalized === 'silent') return false
+  return LEVELS[normalized] >= LEVELS[minimum]
+}
+
+function shouldUseJsonFormat(format: unknown): boolean {
+  return format === 'json' || (format !== 'pretty' && process.env.NODE_ENV === 'production')
+}
+
+function serializeArg(arg: unknown): unknown {
+  if (arg instanceof Error) {
+    return {
+      name: arg.name,
+      message: arg.message,
+      stack: arg.stack,
+      cause: arg.cause,
+    }
+  }
+  return arg
+}
+
+function consoleMethodFor(type: LogType): 'error' | 'warn' | 'info' | 'debug' {
+  if (type === 'error' || type === 'fatal') return 'error'
+  if (type === 'warn') return 'warn'
+  if (type === 'debug' || type === 'trace' || type === 'verbose') return 'debug'
+  return 'info'
+}
+
+function createReporter(json: boolean): ConsolaReporter {
+  return {
+    log(logObj) {
+      const [message, ...args] = logObj.args
+      const method = consoleMethodFor(logObj.type)
+
+      if (json) {
+        const fields = args.length === 1 && args[0] && typeof args[0] === 'object' && !(args[0] instanceof Error)
+          ? args[0] as Record<string, unknown>
+          : undefined
+        const extra = fields ? args.slice(1) : args
+        console[method](JSON.stringify({
+          timestamp: logObj.date.toISOString(),
+          level: logObj.type,
+          tag: logObj.tag,
+          message: typeof message === 'string' ? message : serializeArg(message),
+          ...fields,
+          ...(extra.length > 0 ? { args: extra.map(serializeArg) } : {}),
+        }))
+        return
+      }
+
+      const prefix = logObj.tag ? `[${logObj.tag}]` : ''
+      console[method](prefix, message, ...args)
+    }
+  }
+}
+
+export function createLogger(tag: string): TaggedLogger {
+  const log = (type: 'error' | 'warn' | 'info' | 'debug', message: string, ...args: unknown[]) => {
+    const config = getRuntimeLoggingConfig()
+    const level = normalizeLogLevel(config.logLevel)
+    if (!isLogLevelAtLeast(level, type)) return
+
+    const logger = createConsola({
+      level: LEVELS.debug,
+      reporters: [createReporter(shouldUseJsonFormat(config.logFormat))],
+    }).withTag(tag)
+
+    logger[type](message, ...args)
+  }
+
+  return {
+    error: (message, ...args) => log('error', message, ...args),
+    warn: (message, ...args) => log('warn', message, ...args),
+    info: (message, ...args) => log('info', message, ...args),
+    debug: (message, ...args) => log('debug', message, ...args),
+  }
+}

--- a/server/utils/proxy-agent.ts
+++ b/server/utils/proxy-agent.ts
@@ -12,6 +12,9 @@
 
 import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { readFileSync, existsSync } from 'fs';
+import { createLogger } from './logger';
+
+const logger = createLogger('proxy-agent');
 
 /**
  * Initializes a ProxyAgent from environment variables and sets it as the
@@ -42,11 +45,11 @@ export function initializeProxyAgent(exitOnError = false): ProxyAgent | null {
     });
 
     setGlobalDispatcher(proxyAgent);
-    console.info(`[proxy-agent] Proxy initialized: ${process.env.HTTP_PROXY}`);
+    logger.info(`Proxy initialized: ${process.env.HTTP_PROXY}`);
 
     return proxyAgent;
   } catch (error) {
-    console.error('[proxy-agent] Failed to initialize proxy agent:', error);
+    logger.error('Failed to initialize proxy agent:', error);
     if (exitOnError) process.exit(1);
     throw error;
   }

--- a/tests/server-logger.spec.ts
+++ b/tests/server-logger.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+
+;(globalThis as any).defineEventHandler = (handler: any) => handler
+
+const originalEnv = { ...process.env }
+
+function captureConsole() {
+  const calls: string[] = []
+  const spies = ['error', 'warn', 'info', 'debug', 'log'].map((method) =>
+    vi.spyOn(console, method as keyof Console).mockImplementation((...args: unknown[]) => {
+      calls.push(args.map((arg) => typeof arg === 'string' ? arg : JSON.stringify(arg)).join(' '))
+    })
+  )
+  return { calls, restore: () => spies.forEach(spy => spy.mockRestore()) }
+}
+
+async function importFresh<T>(path: string): Promise<T> {
+  vi.resetModules()
+  return await import(path) as T
+}
+
+function createEvent(url: string, requestId?: string) {
+  const res = new EventEmitter() as EventEmitter & {
+    statusCode: number
+    setHeader: (name: string, value: string) => void
+    getHeader: (name: string) => string | undefined
+    headers: Record<string, string>
+  }
+  res.statusCode = 200
+  res.headers = {}
+  res.setHeader = (name: string, value: string) => { res.headers[name.toLowerCase()] = value }
+  res.getHeader = (name: string) => res.headers[name.toLowerCase()]
+
+  return {
+    method: 'GET',
+    node: {
+      req: {
+        method: 'GET',
+        url,
+        headers: requestId ? { 'x-request-id': requestId } : {}
+      },
+      res
+    },
+    context: {}
+  } as any
+}
+
+beforeEach(() => {
+  process.env = { ...originalEnv }
+  ;(globalThis as any).useRuntimeConfig = () => ({
+    logLevel: 'info',
+    logFormat: 'pretty',
+    logRequests: 'false'
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  process.env = { ...originalEnv }
+})
+
+describe('server logger', () => {
+  it('honors NUXT_LOG_LEVEL from runtime config', async () => {
+    ;(globalThis as any).useRuntimeConfig = () => ({
+      logLevel: 'warn',
+      logFormat: 'pretty',
+      logRequests: 'false'
+    })
+    const captured = captureConsole()
+    const { createLogger } = await importFresh<typeof import('../server/utils/logger')>('../server/utils/logger')
+
+    const logger = createLogger('test')
+    logger.info('hidden info')
+    logger.warn('visible warning')
+
+    expect(captured.calls.join('\n')).not.toContain('hidden info')
+    expect(captured.calls.join('\n')).toContain('visible warning')
+    captured.restore()
+  })
+})
+
+describe('request log middleware', () => {
+  it('skips health endpoints', async () => {
+    ;(globalThis as any).useRuntimeConfig = () => ({
+      logLevel: 'debug',
+      logFormat: 'pretty',
+      logRequests: 'true'
+    })
+    const captured = captureConsole()
+    const middleware = await importFresh<typeof import('../server/middleware/log')>('../server/middleware/log')
+    const event = createEvent('/api/health')
+
+    await middleware.default(event)
+    event.node.res.emit('finish')
+
+    expect(captured.calls).toHaveLength(0)
+    captured.restore()
+  })
+
+  it('redacts query strings from request logs', async () => {
+    ;(globalThis as any).useRuntimeConfig = () => ({
+      logLevel: 'debug',
+      logFormat: 'pretty',
+      logRequests: 'true'
+    })
+    const captured = captureConsole()
+    const middleware = await importFresh<typeof import('../server/middleware/log')>('../server/middleware/log')
+    const event = createEvent('/auth/github?code=secret-code&state=secret-state')
+
+    await middleware.default(event)
+    event.node.res.emit('finish')
+
+    const output = captured.calls.join('\n')
+    expect(output).toContain('/auth/github')
+    expect(output).not.toContain('?code=')
+    expect(output).not.toContain('secret-code')
+    expect(output).not.toContain('secret-state')
+    captured.restore()
+  })
+
+  it('generates a request id when absent', async () => {
+    const middleware = await importFresh<typeof import('../server/middleware/log')>('../server/middleware/log')
+    const event = createEvent('/api/metrics')
+
+    await middleware.default(event)
+
+    expect(event.node.res.getHeader('x-request-id')).toEqual(expect.any(String))
+    expect(event.context.requestId).toBe(event.node.res.getHeader('x-request-id'))
+  })
+
+  it('echoes an existing request id', async () => {
+    const middleware = await importFresh<typeof import('../server/middleware/log')>('../server/middleware/log')
+    const event = createEvent('/api/metrics', 'req-123')
+
+    await middleware.default(event)
+
+    expect(event.node.res.getHeader('x-request-id')).toBe('req-123')
+    expect(event.context.requestId).toBe('req-123')
+  })
+})


### PR DESCRIPTION
Fixes #435

## Summary
- add a tagged consola-backed server logger with runtime log level/format/request controls
- rewrite request logging to skip health/static routes, redact query strings, and propagate x-request-id
- migrate server console logging call sites to tagged loggers
- add Vitest coverage for levels, redaction, skips, and request IDs

## Validation
- npm test -- --run
- npm run build
- npm run lint (fails before linting due eslint-plugin-import-x/minimatch brace-expansion export mismatch)