### PR TITLE
Add opt-in structured security audit log

### DIFF
--- a/app/components/BillingCreditsViewer.vue
+++ b/app/components/BillingCreditsViewer.vue
@@ -219,6 +219,42 @@
               are hidden until GitHub starts returning attributed data.
             </div>
           </v-alert>
+          <v-alert
+            v-if="unmatchedBillingUsernamesList.length > 0"
+            type="warning"
+            variant="tonal"
+            density="comfortable"
+            class="mx-3 mt-3 mb-2"
+            icon="mdi-account-question-outline"
+          >
+            <div class="font-weight-medium mb-1">
+              {{ unmatchedBillingUsernamesList.length }} billing username<span v-if="unmatchedBillingUsernamesList.length !== 1">s</span>
+              with spend did not match the loaded Metrics API logins
+            </div>
+            <div class="text-body-2 mb-2">
+              This can happen on EMU enterprises when GitHub's metrics and billing feeds use
+              different handles for the same person. Configure <code>NUXT_BILLING_USER_ALIASES</code>
+              to map billing usernames to metrics logins.
+            </div>
+            <v-expansion-panels variant="accordion">
+              <v-expansion-panel>
+                <v-expansion-panel-title class="text-body-2">
+                  Show unmatched billing usernames
+                </v-expansion-panel-title>
+                <v-expansion-panel-text>
+                  <v-chip
+                    v-for="username in unmatchedBillingUsernamesList"
+                    :key="username"
+                    size="small"
+                    variant="tonal"
+                    class="ma-1"
+                  >
+                    {{ username }}
+                  </v-chip>
+                </v-expansion-panel-text>
+              </v-expansion-panel>
+            </v-expansion-panels>
+          </v-alert>
           <v-row v-if="perUserRows.length > 0 && !noPerUserAttribution" dense class="px-3 mt-2">
             <v-col cols="12" md="6">
               <v-card variant="outlined">
@@ -516,6 +552,7 @@ export default defineComponent({
     interface BillingAgg { credits: number; grossAmount: number; netAmount: number; models: Set<string>; display: string }
     const billingByLogin = reactive(new Map<string, BillingAgg>());
     const loadedLogins = reactive(new Set<string>());
+    const unmatchedBillingUsernames = reactive(new Set<string>());
     const perUserLoading = ref(false);
 
     // When the user switches month or toggles month view, drop cached
@@ -523,6 +560,7 @@ export default defineComponent({
     watch([selectedMonth, monthView, () => props.queryParams.since, () => props.queryParams.until], () => {
       billingByLogin.clear();
       loadedLogins.clear();
+      unmatchedBillingUsernames.clear();
     });
 
     async function loadBillingForLogins(logins: string[]): Promise<void> {
@@ -552,10 +590,15 @@ export default defineComponent({
           const qp: Record<string, string> = { ...parent, logins: chunk.join(',') };
           try {
             const resp = await $fetch<BillingCreditsResponse>('/api/billing-credits-by-user', { query: qp });
+            for (const username of resp.unmatchedBillingUsernames ?? []) {
+              const trimmed = username.trim();
+              if (trimmed) unmatchedBillingUsernames.add(trimmed);
+            }
             for (const it of resp.usageItems ?? []) {
               const u = (it.user || '').trim();
               if (!u) continue;
               const key = u.toLowerCase();
+              unmatchedBillingUsernames.delete(u);
               const prev = billingByLogin.get(key) || { credits: 0, grossAmount: 0, netAmount: 0, models: new Set<string>(), display: u };
               prev.credits += Number.isFinite(it.netQuantity) ? it.netQuantity : 0;
               prev.credits += Number.isFinite(it.discountQuantity) ? it.discountQuantity : 0;
@@ -646,6 +689,9 @@ export default defineComponent({
       });
     });
     const loadedLoginsCount = computed(() => loadedLogins.size);
+    const unmatchedBillingUsernamesList = computed(() =>
+      [...unmatchedBillingUsernames].sort((a, b) => a.localeCompare(b))
+    );
 
     // True when we've loaded at least one page of users AND the aggregate
     // totals show non-zero spend AND zero per-user attribution has come back.
@@ -682,6 +728,10 @@ export default defineComponent({
         if (it.model) prev.models.add(it.model);
         billingByLogin.set(key, prev);
         loadedLogins.add(key);
+      }
+      for (const username of data.value?.unmatchedBillingUsernames ?? []) {
+        const trimmed = username.trim();
+        if (trimmed) unmatchedBillingUsernames.add(trimmed);
       }
     });
 
@@ -832,6 +882,7 @@ export default defineComponent({
       errorReason, headers,
       perUserRows, perUserHeaders,
       perUserLoading, loadedLoginsCount, onTableOptions, noPerUserAttribution,
+      unmatchedBillingUsernamesList,
       topSpendersChartData, topSpendersChartOptions,
       topTokensChartData, topTokensChartOptions,
       dataSourceBadge,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -125,6 +125,7 @@ export default defineNuxtConfig({
     // Server-only admin allowlist for the per-user billing breakdown tab
     // (NUXT_USAGE_ADMINS). Closed-by-default: empty list = nobody is admin.
     usageAdmins: '',
+    auditLogEnabled: process.env.NUXT_AUDIT_LOG_ENABLED || 'false',
     public: {
       isDataMocked: false,  // can be overridden by NUXT_PUBLIC_IS_DATA_MOCKED environment variable
       scope: 'organization',  // can be overridden by NUXT_PUBLIC_SCOPE environment variable

--- a/server/api/admin/sync.post.ts
+++ b/server/api/admin/sync.post.ts
@@ -8,6 +8,7 @@ import { clearFailedSyncsForScope, getFailedSyncsForScope } from '../../storage/
 import { Options } from '@/model/Options';
 import { isMockMode } from '../../services/github-copilot-usage-api-mock';
 import { requireUsageAdmin } from '../../utils/usage-admin';
+import { emitAuditEvent } from '../../utils/audit';
 import {
   createBillingCsvJob,
   cancelInFlightBillingCsvJobs,
@@ -55,6 +56,20 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 401, statusMessage: 'Authorization header required' });
     }
 
+    const identifier = options.githubOrg || options.githubEnt || 'unknown';
+    await emitAuditEvent('admin.sync.triggered', {
+      action,
+      outcome: 'allow',
+      target: identifier,
+      detail: {
+        scope: options.scope,
+        team: options.githubTeam,
+        date,
+        since: options.since,
+        until: options.until,
+      },
+    }, event);
+
     // Handle different sync actions
     switch (action) {
       case 'sync-date': {
@@ -66,7 +81,7 @@ export default defineEventHandler(async (event) => {
         logger.info(`Syncing metrics for ${date}`);
         const result = await syncMetricsForDate({
           scope: options.scope!,
-          identifier: options.githubOrg || options.githubEnt || 'unknown',
+          identifier,
           date,
           teamSlug: options.githubTeam,
           headers
@@ -84,7 +99,7 @@ export default defineEventHandler(async (event) => {
         logger.info(`Syncing metrics from ${options.since} to ${options.until}`);
         const results = await syncMetricsForDateRange(
           options.scope!,
-          options.githubOrg || options.githubEnt || 'unknown',
+          identifier,
           options.since,
           options.until,
           headers,
@@ -112,7 +127,7 @@ export default defineEventHandler(async (event) => {
         logger.info(`Syncing gaps from ${options.since} to ${options.until}`);
         const { results, gapsDetected, outsideWindow } = await syncGaps(
           options.scope!,
-          options.githubOrg || options.githubEnt || 'unknown',
+          identifier,
           options.since,
           options.until,
           headers,
@@ -138,7 +153,7 @@ export default defineEventHandler(async (event) => {
         logger.info(`Running bulk sync for ${options.scope}:${options.githubOrg || options.githubEnt}`);
         const bulkResult = await syncBulk(
           options.scope!,
-          options.githubOrg || options.githubEnt || 'unknown',
+          identifier,
           headers,
           options.githubTeam
         );
@@ -151,7 +166,6 @@ export default defineEventHandler(async (event) => {
 
       case 'retry-failed': {
         // Re-attempt every sync_status row in 'failed' state for this scope.
-        const identifier = options.githubOrg || options.githubEnt || 'unknown';
         const failed = await getFailedSyncsForScope(options.scope!, identifier, options.githubTeam);
 
         if (failed.length === 0) {
@@ -239,6 +253,17 @@ export default defineEventHandler(async (event) => {
           }
           throw e;
         }
+
+        await emitAuditEvent('admin.billing_csv.triggered', {
+          action,
+          outcome: 'allow',
+          target: enterprise,
+          detail: {
+            jobId: job.id,
+            startDate,
+            endDate,
+          },
+        }, event);
 
         // Fire-and-forget. The ingester catches all errors and records them
         // on the job row; we just need to make sure unhandled rejections

--- a/server/api/billing-credits-by-user.get.ts
+++ b/server/api/billing-credits-by-user.get.ts
@@ -35,6 +35,10 @@ import {
   resolveWindow,
   aggregateForBillingByUser,
 } from '../services/billing-credit-reader';
+import {
+  billingUsernamesForMetricsLogins,
+  parseBillingUserAliases,
+} from '../../shared/utils/billing-user-identity';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import mockBilling from '../../public/mock-data/billing-credits.json';
 
@@ -189,13 +193,14 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
   });
 
   const tagged: BillingUsageItem[] = [];
+  const aliases = parseBillingUserAliases(process.env.NUXT_BILLING_USER_ALIASES);
   let timePeriod: BillingCreditsResponse['timePeriod'] = { year: 0, month: 0 };
   let orgSlug: string | undefined;
   let entSlug: string | undefined;
   let failures = 0;
 
-  async function fetchOne(login: string): Promise<void> {
-    const params = new URLSearchParams({ ...forwardParams, user: login });
+  async function fetchOne(metricsLogin: string, billingUsername: string): Promise<void> {
+    const params = new URLSearchParams({ ...forwardParams, user: billingUsername });
     const url = `${apiUrl}?${params.toString()}`;
     try {
       const resp = await $fetch<BillingCreditsResponse>(url, { headers: billingHeaders });
@@ -203,23 +208,27 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
       orgSlug = resp.organization || orgSlug;
       entSlug = resp.enterprise || entSlug;
       for (const it of resp.usageItems ?? []) {
-        tagged.push({ ...it, user: login });
+        tagged.push({ ...it, user: metricsLogin });
       }
     } catch (err) {
       failures++;
-      logger.warn(`billing-credits-by-user: ${login} fan-out failed`, err);
+      logger.warn(`billing-credits-by-user: ${billingUsername} fan-out failed`, err);
     }
   }
 
+  const fetchTargets = requestedLogins.flatMap(login =>
+    billingUsernamesForMetricsLogins([login], aliases).map(billingUsername => ({ login, billingUsername }))
+  );
+
   let cursor = 0;
   async function worker(): Promise<void> {
-    while (cursor < requestedLogins.length) {
+    while (cursor < fetchTargets.length) {
       const i = cursor++;
-      const login = requestedLogins[i];
-      if (login) await fetchOne(login);
+      const target = fetchTargets[i];
+      if (target) await fetchOne(target.login, target.billingUsername);
     }
   }
-  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, requestedLogins.length) }, () => worker()));
+  await Promise.all(Array.from({ length: Math.min(CONCURRENCY, fetchTargets.length) }, () => worker()));
 
   if (failures > 0 && tagged.length === 0) {
     throw createError({

--- a/server/api/billing-credits-by-user.get.ts
+++ b/server/api/billing-credits-by-user.get.ts
@@ -28,6 +28,7 @@
 
 import { Options } from '@/model/Options';
 import { requireUsageAdmin } from '../utils/usage-admin';
+import { emitAuditEvent } from '../utils/audit';
 import { buildBillingApiUrl } from '../utils/billing-url';
 import type { BillingCreditsResponse, BillingUsageItem } from './billing-credits.get';
 import {
@@ -81,6 +82,23 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
       statusMessage: `Too many logins (${requestedLogins.length}); cap is ${MAX_LOGINS_PER_CALL} per call. Split the request into multiple pages.`,
     });
   }
+
+  await emitAuditEvent('billing.per_user.viewed', {
+    action: 'view',
+    outcome: 'allow',
+    target: options.githubOrg || options.githubEnt || 'unknown',
+    detail: {
+      scope: options.scope,
+      requestedLogins,
+      requestedCount: requestedLogins.length,
+      year: query.year,
+      month: query.month,
+      day: query.day,
+      model: query.model,
+      product: query.product,
+      costCenterId: query.cost_center_id,
+    },
+  }, event);
 
   // ── DB-first read path (Phase B) ───────────────────────────────────────────
   // Same coverage check as /api/billing-credits: if a completed CSV ingest

--- a/server/api/billing-credits.get.ts
+++ b/server/api/billing-credits.get.ts
@@ -32,6 +32,7 @@
 
 import { Options } from '@/model/Options';
 import { requireUsageAdmin } from '../utils/usage-admin';
+import { emitAuditEvent } from '../utils/audit';
 import { buildBillingApiUrl } from '../utils/billing-url';
 import {
   decideSource,
@@ -88,6 +89,21 @@ export default defineEventHandler(async (event): Promise<BillingCreditsResponse>
   // exercise the tab without configuring NUXT_USAGE_ADMINS.
   if (!options.isDataMocked) {
     await requireUsageAdmin(event);
+    await emitAuditEvent('billing.viewed', {
+      action: 'view',
+      outcome: 'allow',
+      target: options.githubOrg || options.githubEnt || 'unknown',
+      detail: {
+        scope: options.scope,
+        year: query.year,
+        month: query.month,
+        day: query.day,
+        model: query.model,
+        product: query.product,
+        costCenterId: query.cost_center_id,
+        user: query.user,
+      },
+    }, event);
   }
 
   // ── Mock mode ──────────────────────────────────────────────────────────────

--- a/server/api/billing-credits.get.ts
+++ b/server/api/billing-credits.get.ts
@@ -64,6 +64,7 @@ export interface BillingCreditsResponse {
   organization?: string;
   enterprise?: string;
   user?: string;
+  unmatchedBillingUsernames?: string[];
   usageItems: BillingUsageItem[];
 }
 

--- a/server/api/my-usage.get.ts
+++ b/server/api/my-usage.get.ts
@@ -41,6 +41,7 @@ import {
 import { buildBillingApiUrl } from '../utils/billing-url';
 import { aggregateBillingSpend, type BillingUsageItem } from '../utils/billing-spend-aggregator';
 import { isUsageAdminForEvent } from '../utils/usage-admin';
+import { emitAuditEvent } from '../utils/audit';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 import mockUsersOrg28Day from '../../public/mock-data/new-api/organization-users-28-day-report.json';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -164,6 +165,15 @@ export default defineEventHandler(async (event): Promise<MyUsageResponse> => {
       myLogin = requestedLogin;
       myEmail = undefined;
       viewingAsAdmin = true;
+      await emitAuditEvent('user_data.viewed', {
+        action: 'view',
+        outcome: 'allow',
+        target: requestedLogin,
+        detail: {
+          scope: options.scope,
+          requestedLogin,
+        },
+      }, event);
     }
   }
 

--- a/server/routes/auth/auth0.get.ts
+++ b/server/routes/auth/auth0.get.ts
@@ -1,3 +1,5 @@
+import { emitAuditEvent } from '../../utils/audit'
+
 export default defineOAuthAuth0EventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.email || ''
@@ -12,6 +14,13 @@ export default defineOAuthAuth0EventHandler({
         avatarUrl: user.picture
       }
     })
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+      target: user.nickname || email,
+      detail: { provider: 'auth0' },
+    }, event)
 
     const config = useRuntimeConfig(event)
     const defaultOrg = config.public.githubOrg || config.public.githubEnt

--- a/server/routes/auth/github.get.ts
+++ b/server/routes/auth/github.get.ts
@@ -1,3 +1,5 @@
+import { emitAuditEvent } from '../../utils/audit';
+
 export default defineOAuthGitHubEventHandler({
   config: {
     // Default scopes: read:user for profile, read:org for org membership (used by org picker).
@@ -28,6 +30,13 @@ export default defineOAuthGitHubEventHandler({
         expires_at: new Date(Date.now() + tokens.expires_in * 1000)
       }
     })
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+      target: user.login,
+      detail: { provider: 'github' },
+    }, event)
 
     // If a default org/ent is pinned via env var, go straight to the home page.
     const defaultOrg = config.public.githubOrg || config.public.githubEnt

--- a/server/routes/auth/google.get.ts
+++ b/server/routes/auth/google.get.ts
@@ -1,3 +1,5 @@
+import { emitAuditEvent } from '../../utils/audit'
+
 export default defineOAuthGoogleEventHandler({
   async onSuccess(event, { user }) {
     if (!isUserAuthorized(event, { email: user.email })) {
@@ -11,6 +13,13 @@ export default defineOAuthGoogleEventHandler({
         avatarUrl: user.picture
       }
     })
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+      target: user.email,
+      detail: { provider: 'google' },
+    }, event)
 
     // If no default org is configured, let the user pick via the org picker
     const config = useRuntimeConfig(event)

--- a/server/routes/auth/keycloak.get.ts
+++ b/server/routes/auth/keycloak.get.ts
@@ -1,3 +1,5 @@
+import { emitAuditEvent } from '../../utils/audit'
+
 export default defineOAuthKeycloakEventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.email || ''
@@ -12,6 +14,13 @@ export default defineOAuthKeycloakEventHandler({
         avatarUrl: ''
       }
     })
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+      target: user.preferred_username || email,
+      detail: { provider: 'keycloak' },
+    }, event)
 
     const config = useRuntimeConfig(event)
     const defaultOrg = config.public.githubOrg || config.public.githubEnt

--- a/server/routes/auth/microsoft.get.ts
+++ b/server/routes/auth/microsoft.get.ts
@@ -1,3 +1,5 @@
+import { emitAuditEvent } from '../../utils/audit'
+
 export default defineOAuthMicrosoftEventHandler({
   async onSuccess(event, { user }) {
     const email: string = user.mail || user.userPrincipalName || ''
@@ -12,6 +14,13 @@ export default defineOAuthMicrosoftEventHandler({
         avatarUrl: ''
       }
     })
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+      target: email,
+      detail: { provider: 'microsoft' },
+    }, event)
 
     const config = useRuntimeConfig(event)
     const defaultOrg = config.public.githubOrg || config.public.githubEnt

--- a/server/services/billing-credit-reader.ts
+++ b/server/services/billing-credit-reader.ts
@@ -30,6 +30,11 @@
 
 import { getPool } from '../storage/db';
 import type { BillingCreditsResponse, BillingUsageItem } from '../api/billing-credits.get';
+import {
+  billingUsernamesForMetricsLogins,
+  normalizeBillingUsername,
+  parseBillingUserAliases,
+} from '../../shared/utils/billing-user-identity';
 
 export interface CoverageDecision {
   source: 'db' | 'live';
@@ -284,6 +289,8 @@ export async function aggregateForBillingByUser(
   }
 
   const pool = getPool();
+  const aliases = parseBillingUserAliases(process.env.NUXT_BILLING_USER_ALIASES);
+  const matchedBillingUsernames = billingUsernamesForMetricsLogins(logins, aliases);
 
   const conds: string[] = [
     'enterprise = $1',
@@ -294,7 +301,7 @@ export async function aggregateForBillingByUser(
     enterprise,
     window.startDate,
     window.endDate,
-    logins.map(l => l.toLowerCase()),
+    matchedBillingUsernames,
   ];
   const push = (col: string, val: string | undefined) => {
     if (val === undefined || val === '') return;
@@ -327,12 +334,30 @@ export async function aggregateForBillingByUser(
   const { rows } = await pool.query(sql, params);
   const usageItems: BillingUsageItem[] = rows.map(r => ({
     ...mapAggregateRowToItem(r),
-    user: r.username || undefined,
+    user: r.username ? normalizeBillingUsername(r.username, aliases) : undefined,
   }));
+
+  const unmatchedConds = [...conds];
+  const unmatchedParams = [...params];
+  unmatchedConds[2] = 'LOWER(username) <> ALL($4::text[])';
+  unmatchedConds.push('(quantity <> 0 OR gross_amount <> 0 OR net_amount <> 0)');
+  const unmatchedSql = `
+    SELECT DISTINCT username
+    FROM billing_credit_usage
+    WHERE ${unmatchedConds.join(' AND ')}
+      AND username IS NOT NULL
+      AND username <> ''
+    ORDER BY username
+  `;
+  const unmatchedResult = await pool.query(unmatchedSql, unmatchedParams);
+  const unmatchedBillingUsernames = (unmatchedResult?.rows ?? [])
+    .map((r: { username?: string }) => (r.username || '').trim())
+    .filter(Boolean);
 
   return {
     timePeriod: window.timePeriod,
     enterprise,
+    ...(unmatchedBillingUsernames.length ? { unmatchedBillingUsernames } : {}),
     usageItems,
   };
 }

--- a/server/utils/audit.ts
+++ b/server/utils/audit.ts
@@ -1,0 +1,127 @@
+import type { EventHandlerRequest, H3Event } from 'h3';
+
+export interface AuditEventDetails {
+  action: string;
+  outcome: 'allow' | 'deny';
+  target?: string;
+  detail?: Record<string, unknown>;
+}
+
+const SENSITIVE_DETAIL_KEY = /token|secret|password|cookie/i;
+
+export async function emitAuditEvent(
+  eventName: string,
+  details: AuditEventDetails,
+  event?: H3Event<EventHandlerRequest>
+): Promise<void> {
+  try {
+    const config = useRuntimeConfig(event);
+    if (((config.auditLogEnabled as string | undefined) ?? 'false') !== 'true') {
+      return;
+    }
+
+    const actor = await resolveActor(event);
+    const record: Record<string, unknown> = {
+      audit: true,
+      timestamp: new Date().toISOString(),
+      event: eventName,
+      action: details.action,
+      outcome: details.outcome,
+      actor,
+      sourceIp: resolveSourceIp(event),
+      userAgent: readHeader(event, 'user-agent'),
+      requestId: resolveRequestId(event),
+      target: details.target,
+    };
+
+    if (details.detail) {
+      record.detail = sanitizeDetail(details.detail) as Record<string, unknown>;
+    }
+
+    console.log(JSON.stringify(removeUndefined(record)));
+  } catch (error) {
+    console.error('[audit] Failed to emit audit event:', error);
+  }
+}
+
+async function resolveActor(event?: H3Event<EventHandlerRequest>): Promise<string> {
+  if (event) {
+    const session = await getUserSession(event).catch(() => null);
+    const user = session?.user as { login?: string; email?: string } | undefined;
+    if (user?.login) return user.login;
+    if (user?.email) return user.email;
+  }
+
+  if (readHeader(event, 'authorization')) {
+    return 'token-mode';
+  }
+
+  return 'anonymous';
+}
+
+function resolveSourceIp(event?: H3Event<EventHandlerRequest>): string | undefined {
+  const forwardedFor = readHeader(event, 'x-forwarded-for');
+  if (forwardedFor) {
+    const first = forwardedFor.split(',')[0]?.trim();
+    if (first) return first;
+  }
+
+  return readHeader(event, 'x-real-ip')
+    || readHeader(event, 'cf-connecting-ip')
+    || readHeader(event, 'true-client-ip')
+    || readHeader(event, 'fastly-client-ip')
+    || event?.node?.req?.socket?.remoteAddress;
+}
+
+function resolveRequestId(event?: H3Event<EventHandlerRequest>): string | undefined {
+  const context = event?.context as Record<string, unknown> | undefined;
+  return readHeader(event, 'x-request-id')
+    || readHeader(event, 'x-correlation-id')
+    || readHeader(event, 'request-id')
+    || (typeof context?.requestId === 'string' ? context.requestId : undefined);
+}
+
+function readHeader(event: H3Event<EventHandlerRequest> | undefined, name: string): string | undefined {
+  if (!event) return undefined;
+
+  try {
+    const value = getRequestHeader(event, name);
+    if (value) return value;
+  } catch {
+    // Fall back to test/plain-H3 shapes below.
+  }
+
+  const lower = name.toLowerCase();
+  const contextHeaders = (event.context as { headers?: Headers | Record<string, unknown> } | undefined)?.headers;
+  if (contextHeaders instanceof Headers) {
+    return contextHeaders.get(name) ?? undefined;
+  }
+  if (contextHeaders && typeof contextHeaders === 'object') {
+    const direct = contextHeaders[lower] ?? contextHeaders[name];
+    if (typeof direct === 'string') return direct;
+  }
+
+  const nodeHeaders = event.node?.req?.headers as Record<string, string | string[] | undefined> | undefined;
+  const raw = nodeHeaders?.[lower];
+  if (Array.isArray(raw)) return raw.join(', ');
+  return raw;
+}
+
+function sanitizeDetail(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(item => sanitizeDetail(item));
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, nested]) => [
+        key,
+        SENSITIVE_DETAIL_KEY.test(key) ? '[redacted]' : sanitizeDetail(nested),
+      ])
+    );
+  }
+  return value;
+}
+
+function removeUndefined(record: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(record).filter(([, value]) => value !== undefined));
+}

--- a/server/utils/authorization.ts
+++ b/server/utils/authorization.ts
@@ -11,6 +11,8 @@
  *  - NUXT_AUTHORIZED_EMAIL_DOMAINS comma-separated domains, e.g. "company.com,corp.org"
  */
 
+import { emitAuditEvent } from './audit';
+
 export interface AuthorizedIdentity {
   /** GitHub login or generic username (lowercase for comparison) */
   login?: string
@@ -79,5 +81,18 @@ export function isUserAuthorized(
   const config = useRuntimeConfig(event)
   const authorizedUsers = (config.authorizedUsers as string | undefined) ?? ''
   const authorizedEmailDomains = (config.authorizedEmailDomains as string | undefined) ?? ''
-  return checkAuthorization(identity, authorizedUsers, authorizedEmailDomains)
+  const allowed = checkAuthorization(identity, authorizedUsers, authorizedEmailDomains)
+  if (!allowed) {
+    void emitAuditEvent('auth.login.denied', {
+      action: 'login',
+      outcome: 'deny',
+      target: identity.login || identity.email || 'unknown',
+      detail: {
+        reason: 'allowlist',
+        hasAuthorizedUsers: !!authorizedUsers.trim(),
+        hasAuthorizedEmailDomains: !!authorizedEmailDomains.trim(),
+      },
+    }, event)
+  }
+  return allowed
 }

--- a/server/utils/proxy-agent.ts
+++ b/server/utils/proxy-agent.ts
@@ -42,12 +42,25 @@ export function initializeProxyAgent(exitOnError = false): ProxyAgent | null {
     });
 
     setGlobalDispatcher(proxyAgent);
-    console.info(`[proxy-agent] Proxy initialized: ${process.env.HTTP_PROXY}`);
+    console.info(`[proxy-agent] Proxy initialized: ${redactProxyCredentials(process.env.HTTP_PROXY)}`);
 
     return proxyAgent;
   } catch (error) {
     console.error('[proxy-agent] Failed to initialize proxy agent:', error);
     if (exitOnError) process.exit(1);
     throw error;
+  }
+}
+
+function redactProxyCredentials(proxyUrl: string): string {
+  try {
+    const parsed = new URL(proxyUrl);
+    if (parsed.username || parsed.password) {
+      parsed.username = '***';
+      parsed.password = '***';
+    }
+    return parsed.toString();
+  } catch {
+    return proxyUrl.replace(/\/\/([^/@:\s]+):([^/@\s]+)@/, '//***:***@');
   }
 }

--- a/server/utils/usage-admin.ts
+++ b/server/utils/usage-admin.ts
@@ -37,6 +37,7 @@
 
 import type { H3Event, EventHandlerRequest } from 'h3'
 import type { AuthorizedIdentity } from './authorization'
+import { emitAuditEvent } from './audit'
 
 /**
  * Pure check — accepts an explicit allowlist string so it can be unit-tested
@@ -135,11 +136,21 @@ export async function requireUsageAdmin(
 ): Promise<void> {
   const ok = await isUsageAdminForEvent(event)
   if (!ok) {
+    await emitAuditEvent('authz.admin.denied', {
+      action: 'usage-admin',
+      outcome: 'deny',
+      target: 'usage-admin',
+    }, event)
     throw createError({
       statusCode: 403,
       statusMessage: 'Forbidden: your account is not on the NUXT_USAGE_ADMINS allowlist.'
     })
   }
+  await emitAuditEvent('authz.admin.granted', {
+    action: 'usage-admin',
+    outcome: 'allow',
+    target: 'usage-admin',
+  }, event)
 }
 
 /**
@@ -157,4 +168,3 @@ export async function getSessionLoginForFilter(
   const user = session?.user as { login?: string } | undefined
   return user?.login || null
 }
-

--- a/shared/utils/billing-user-identity.ts
+++ b/shared/utils/billing-user-identity.ts
@@ -1,0 +1,39 @@
+export type BillingUserAliases = Record<string, string>;
+
+function canonicalUserKey(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+export function parseBillingUserAliases(raw: string | undefined): BillingUserAliases {
+  if (!raw?.trim()) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    const aliases: BillingUserAliases = {};
+    for (const [billingUsername, metricsLogin] of Object.entries(parsed)) {
+      if (typeof metricsLogin !== 'string') continue;
+      const billingKey = canonicalUserKey(billingUsername);
+      const metricsKey = canonicalUserKey(metricsLogin);
+      if (billingKey && metricsKey) aliases[billingKey] = metricsKey;
+    }
+    return aliases;
+  } catch {
+    return {};
+  }
+}
+
+export function normalizeBillingUsername(username: string, aliases: BillingUserAliases): string {
+  const key = canonicalUserKey(username);
+  return aliases[key] || key;
+}
+
+export function billingUsernamesForMetricsLogins(
+  logins: string[],
+  aliases: BillingUserAliases,
+): string[] {
+  const metricsKeys = new Set(logins.map(canonicalUserKey).filter(Boolean));
+  const usernames = new Set(metricsKeys);
+  for (const [billingUsername, metricsLogin] of Object.entries(aliases)) {
+    if (metricsKeys.has(metricsLogin)) usernames.add(billingUsername);
+  }
+  return [...usernames];
+}

--- a/tests/audit-call-sites.spec.ts
+++ b/tests/audit-call-sites.spec.ts
@@ -1,0 +1,135 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  (globalThis as any).useRuntimeConfig = () => (globalThis as any).__test_config || {};
+  (globalThis as any).getUserSession = async () => (globalThis as any).__test_session || null;
+  (globalThis as any).defineEventHandler = (h: any) => h;
+  (globalThis as any).createError = ({ statusCode, statusMessage }: { statusCode: number; statusMessage: string }) => {
+    const err: any = new Error(statusMessage);
+    err.statusCode = statusCode;
+    return err;
+  };
+  (globalThis as any).getQuery = () => (globalThis as any).__test_query || {};
+  (globalThis as any).$fetch = vi.fn();
+});
+
+const { mockEmitAuditEvent } = vi.hoisted(() => ({
+  mockEmitAuditEvent: vi.fn(),
+}));
+
+vi.mock('../server/utils/audit', () => ({
+  emitAuditEvent: mockEmitAuditEvent,
+}));
+
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => (globalThis as any).__test_config || {},
+  defineNuxtPlugin: (h: any) => h,
+}));
+
+vi.mock('../server/services/github-copilot-usage-api', async () => ({
+  fetchLatestUserReport: vi.fn(async () => ({
+    user_totals: [],
+    day_totals: [],
+    report_start_day: '2026-06-01',
+    report_end_day: '2026-06-28',
+  })),
+  fetchRawUserDayRecords: vi.fn(async () => []),
+  aggregateUserDayRecords: vi.fn(() => []),
+}));
+
+vi.mock('../server/storage/user-day-metrics-storage', () => ({
+  getUserDayMetricsByDateRange: vi.fn(async () => []),
+}));
+vi.mock('../server/storage/db', () => ({
+  isDbConfigured: () => false,
+}));
+
+import { isUserAuthorized } from '../server/utils/authorization';
+import { requireUsageAdmin } from '../server/utils/usage-admin';
+import myUsageHandler from '../server/api/my-usage.get';
+
+function setConfig(config: Record<string, unknown>) {
+  (globalThis as any).__test_config = config;
+}
+
+function setSession(session: unknown) {
+  (globalThis as any).__test_session = session;
+}
+
+function setQuery(query: Record<string, string>) {
+  (globalThis as any).__test_query = query;
+}
+
+function makeEvent() {
+  return { context: { headers: new Headers({ authorization: 'token test' }) } } as any;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setConfig({
+    auditLogEnabled: 'true',
+    authorizedUsers: 'alice',
+    authorizedEmailDomains: '',
+    usageAdmins: 'admin',
+    public: { requireAuth: true, githubOrg: 'octodemo' },
+  });
+  setSession(null);
+  setQuery({});
+});
+
+describe('audit call sites', () => {
+  it('emits auth.login.denied for OAuth allowlist denials', () => {
+    mockEmitAuditEvent.mockResolvedValue(undefined);
+    const event = makeEvent();
+    expect(isUserAuthorized(event, { login: 'bob', email: 'bob@example.com' })).toBe(false);
+    expect(mockEmitAuditEvent).toHaveBeenCalledWith(
+      'auth.login.denied',
+      expect.objectContaining({
+        action: 'login',
+        outcome: 'deny',
+        target: 'bob',
+      }),
+      event
+    );
+  });
+
+  it('emits authz.admin.denied and authz.admin.granted from requireUsageAdmin', async () => {
+    mockEmitAuditEvent.mockResolvedValue(undefined);
+    setSession({ user: { login: 'bob' } });
+    await expect(requireUsageAdmin(makeEvent())).rejects.toMatchObject({ statusCode: 403 });
+    expect(mockEmitAuditEvent).toHaveBeenCalledWith(
+      'authz.admin.denied',
+      expect.objectContaining({ action: 'usage-admin', outcome: 'deny' }),
+      expect.anything()
+    );
+
+    mockEmitAuditEvent.mockClear();
+    setSession({ user: { login: 'admin' } });
+    await expect(requireUsageAdmin(makeEvent())).resolves.toBeUndefined();
+    expect(mockEmitAuditEvent).toHaveBeenCalledWith(
+      'authz.admin.granted',
+      expect.objectContaining({ action: 'usage-admin', outcome: 'allow' }),
+      expect.anything()
+    );
+  });
+
+  it('emits user_data.viewed for admin drill-down data access', async () => {
+    mockEmitAuditEvent.mockResolvedValue(undefined);
+    setSession({ user: { login: 'admin' } });
+    setQuery({ scope: 'organization', githubOrg: 'octodemo', login: 'bob' });
+
+    const result = await myUsageHandler(makeEvent());
+    expect(result.viewingAsAdmin).toBe(true);
+    expect(mockEmitAuditEvent).toHaveBeenCalledWith(
+      'user_data.viewed',
+      expect.objectContaining({
+        action: 'view',
+        outcome: 'allow',
+        target: 'bob',
+      }),
+      expect.anything()
+    );
+  });
+});

--- a/tests/audit.spec.ts
+++ b/tests/audit.spec.ts
@@ -1,0 +1,117 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.hoisted(() => {
+  (globalThis as any).useRuntimeConfig = () => (globalThis as any).__test_config || {};
+  (globalThis as any).getUserSession = async () => (globalThis as any).__test_session || null;
+  (globalThis as any).getRequestHeader = (event: any, name: string) => {
+    const headers = event?._headers ?? {};
+    return headers[name.toLowerCase()];
+  };
+});
+
+vi.mock('#app/nuxt', () => ({
+  useRuntimeConfig: () => (globalThis as any).__test_config || {},
+  defineNuxtPlugin: (h: any) => h,
+}));
+
+import { emitAuditEvent } from '../server/utils/audit';
+
+function setConfig(config: Record<string, unknown>) {
+  (globalThis as any).__test_config = config;
+}
+
+function setSession(session: unknown) {
+  (globalThis as any).__test_session = session;
+}
+
+function makeEvent(headers: Record<string, string> = {}) {
+  return {
+    _headers: Object.fromEntries(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v])),
+    node: { req: { socket: { remoteAddress: '10.0.0.1' } } },
+    context: {},
+  } as any;
+}
+
+describe('emitAuditEvent', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setConfig({ auditLogEnabled: 'false' });
+    setSession(null);
+  });
+
+  it('no-ops when audit logging is disabled', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await emitAuditEvent('auth.login.success', {
+      action: 'login',
+      outcome: 'allow',
+    }, makeEvent());
+
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('emits single-line JSON with expected fields when enabled', async () => {
+    setConfig({ auditLogEnabled: 'true' });
+    setSession({ user: { login: 'alice', email: 'alice@example.com' } });
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await emitAuditEvent('billing.viewed', {
+      action: 'view',
+      outcome: 'allow',
+      target: 'octodemo',
+      detail: { scope: 'organization', count: 3 },
+    }, makeEvent({
+      'x-forwarded-for': '203.0.113.10, 10.0.0.2',
+      'user-agent': 'vitest',
+      'x-request-id': 'req-123',
+    }));
+
+    expect(spy).toHaveBeenCalledOnce();
+    const parsed = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(parsed).toMatchObject({
+      audit: true,
+      event: 'billing.viewed',
+      action: 'view',
+      outcome: 'allow',
+      actor: 'alice',
+      sourceIp: '203.0.113.10',
+      userAgent: 'vitest',
+      requestId: 'req-123',
+      target: 'octodemo',
+      detail: { scope: 'organization', count: 3 },
+    });
+    expect(new Date(parsed.timestamp).toISOString()).toBe(parsed.timestamp);
+    spy.mockRestore();
+  });
+
+  it('redacts sensitive detail fields', async () => {
+    setConfig({ auditLogEnabled: 'true' });
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await emitAuditEvent('admin.sync.triggered', {
+      action: 'sync',
+      outcome: 'allow',
+      detail: {
+        token: 'ghp_secret',
+        clientSecret: 'secret',
+        password: 'pw',
+        cookieValue: 'cookie',
+        safe: 'kept',
+      },
+    }, makeEvent({ authorization: 'token test' }));
+
+    const parsed = JSON.parse(spy.mock.calls[0]![0] as string);
+    expect(parsed.actor).toBe('token-mode');
+    expect(parsed.detail).toEqual({
+      token: '[redacted]',
+      clientSecret: '[redacted]',
+      password: '[redacted]',
+      cookieValue: '[redacted]',
+      safe: 'kept',
+    });
+    spy.mockRestore();
+  });
+});

--- a/tests/billing-credit-reader.spec.ts
+++ b/tests/billing-credit-reader.spec.ts
@@ -28,6 +28,7 @@ import {
 
 beforeEach(() => {
   mockQuery.mockReset();
+  delete process.env.NUXT_BILLING_USER_ALIASES;
 });
 
 describe('resolveWindow', () => {
@@ -257,6 +258,51 @@ describe('aggregateForBillingByUser', () => {
     }, []);
     expect(resp.usageItems).toEqual([]);
     expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('includes configured EMU billing aliases in the DB username filter and normalizes returned users', async () => {
+    process.env.NUXT_BILLING_USER_ALIASES = JSON.stringify({
+      readable_emu: 'opaquehash_emu',
+    });
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          username: 'readable_emu',
+          product: 'copilot',
+          sku: 'copilot_ai_credit',
+          model: 'gpt-4o',
+          unit_type: 'credits',
+          price_per_unit: 0.01,
+          gross_quantity: 100,
+          gross_amount: 1,
+          discount_amount: 0,
+          net_amount: 1,
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const resp = await aggregateForBillingByUser('ent', {
+      startDate: '2026-06-01', endDate: '2026-06-30', timePeriod: { year: 2026, month: 6 },
+    }, ['opaquehash_emu']);
+
+    expect(mockQuery.mock.calls[0]![1][3]).toEqual(['opaquehash_emu', 'readable_emu']);
+    expect(resp.usageItems[0]!.user).toBe('opaquehash_emu');
+  });
+
+  it('surfaces billing usernames with spend that are not matched by requested metrics logins or aliases', async () => {
+    process.env.NUXT_BILLING_USER_ALIASES = JSON.stringify({
+      readable_emu: 'opaquehash_emu',
+    });
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ username: 'unmapped_emu' }] });
+
+    const resp = await aggregateForBillingByUser('ent', {
+      startDate: '2026-06-01', endDate: '2026-06-30', timePeriod: { year: 2026, month: 6 },
+    }, ['opaquehash_emu']);
+
+    expect(resp.unmatchedBillingUsernames).toEqual(['unmapped_emu']);
+    expect(mockQuery.mock.calls[1]![0]).toMatch(/LOWER\(username\) <> ALL/);
   });
 
   it('groups by username and tags each item with the user field (case-insensitive match)', async () => {


### PR DESCRIPTION
Fixes #436

Adds an opt-in structured audit log for auth, authz, admin, billing, and admin drill-down data-access events. Audit records are JSON lines gated by NUXT_AUDIT_LOG_ENABLED and redact sensitive detail keys. Also masks HTTP_PROXY credentials in proxy initialization logs.