### PR TITLE
Retain managed environment after preview cleanup

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -447,8 +447,8 @@ jobs:
             if (!prNumber) return;
             const action = '${{ github.event.action }}';
             const reason = action === 'closed' ? 'PR was merged/closed' : 'deploy label was removed';
-            const body = `## 🧹 Preview Apps Cleaned Up\n\n` +
-              `The preview apps have been removed (${reason}). The shared managed environment was retained for future deployments.`;
+            const body = `## 🧹 Shared Preview Apps Cleaned Up\n\n` +
+              `The shared preview apps have been removed (${reason}). The shared managed environment was retained for future deployments.`;
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -438,14 +438,6 @@ jobs:
             --yes \
             || true
 
-      - name: Delete managed environment
-        run: |
-          az containerapp env delete \
-            --name ${{ env.PREVIEW_ENV_NAME }} \
-            --resource-group ${{ secrets.AZURE_RESOURCE_GROUP }} \
-            --yes \
-            || true
-
       - name: Comment on PR about cleanup
         if: ${{ env.PR_NUMBER != '' }}
         uses: actions/github-script@v7
@@ -455,8 +447,8 @@ jobs:
             if (!prNumber) return;
             const action = '${{ github.event.action }}';
             const reason = action === 'closed' ? 'PR was merged/closed' : 'deploy label was removed';
-            const body = `## 🧹 Preview Environment Cleaned Up\n\n` +
-              `The preview environment has been removed (${reason}).`;
+            const body = `## 🧹 Preview Apps Cleaned Up\n\n` +
+              `The preview apps have been removed (${reason}). The shared managed environment was retained for future deployments.`;
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Summary
- delete the preview app, PostgreSQL app, and sync job during cleanup
- retain the shared Azure Container Apps managed environment for future previews
- update the PR cleanup comment to describe the retained environment

## Rationale
An empty consumption-based Container Apps managed environment has no ACA compute charge. Retaining it avoids repeatedly deleting and recreating the shared environment.

## Validation
- parsed `.github/workflows/preview-deploy.yml` successfully
- `git diff --check` passed

## Security
- `npm audit --audit-level=high --omit=dev` reports the existing high-severity `brace-expansion` advisory; this workflow-only change does not alter dependencies